### PR TITLE
地図上に踏切マーカーを表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,10 @@ gem 'config'
 
 gem 'enum_help'
 
+gem 'leaflet-rails'
+
+gem 'leaflet-markercluster-rails'
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.8", ">= 7.0.8.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,11 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
+    leaflet-markercluster-rails (0.7.0)
+      railties (>= 3.1)
+    leaflet-rails (1.9.5)
+      actionpack (>= 4.2.0)
+      railties (>= 4.2.0)
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -418,6 +423,8 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   kaminari (= 1.2.2)
+  leaflet-markercluster-rails
+  leaflet-rails
   pg
   pry
   pry-byebug

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,3 @@
+//= require leaflet.markercluster
+//= require leaflet.markercluster.default
 @import "bootstrap";

--- a/app/controllers/map_pages_controller.rb
+++ b/app/controllers/map_pages_controller.rb
@@ -1,5 +1,12 @@
 class MapPagesController < ApplicationController
   skip_before_action :require_login, only: %i[top]
   
-  def top; end
+  def top
+    @q = Crossing.ransack(params[:q])
+    if params[:q].blank?
+      @crossings = []  # params[:q]が空なら、検索結果は空
+    else
+      @crossings = @q.result(distinct: true).includes(:linked_cities)
+    end
+  end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,5 +2,6 @@
 //= require jquery3
 //= require popper
 //= require bootstrap
+//= require leaflet.markercluster
 import "@hotwired/turbo-rails"
 import "controllers"

--- a/app/views/map_pages/top.html.erb
+++ b/app/views/map_pages/top.html.erb
@@ -1,4 +1,15 @@
-<div id="map" style="width: 100%; height: 800px;"></div>
+<div class="position-relative">
+  <div class="search_form position-absolute top-0 start-50 translate-middle-x z-1">
+    <%= form_with model: @q, scope: :q, url: root_path, method: :get, class: 'd-flex justify-content-evenly p-2' do |f| %>
+    <%= f.select :linked_prefectures_prefecture_id_eq, Prefecture.pluck(:prefecture_name, :prefecture_id), { include_blank: '都道府県' }, class: 'form-select shadow m-2' %>
+    <%= f.select :linked_cities_city_id_eq, City.pluck(:city_name, :city_id), { include_blank: '市町村' }, class: 'form-select shadow m-2' %>
+    <%= f.select :linked_railways_railway_id_eq, Railway.pluck(:railway_name, :railway_id), { include_blank: '路線' }, class: 'form-select shadow m-2' %>
+    <%= f.submit '検索', class: 'btn btn-warning shadow m-2' %>
+  <% end %>
+  </div>
+  <div class="z-0" id="map" style="width: 100%; height: 800px;"></div>
+</div>
+
 <script>
   // 地図の初期設定
   var map = L.map('map').setView([35.6895, 139.6917], 13);  // 東京の緯度経度を指定
@@ -9,6 +20,7 @@
   }).addTo(map);
 
   // マーカーの追加（必要に応じて）
-  var marker = L.marker([35.6895, 139.6917]).addTo(map)
-    .openPopup();
+  <% @crossings.each do |crossing| %>
+    var marker = L.marker([<%= crossing.latitude %>, <%= crossing.longitude %>]).addTo(map).bindPopup("<%= crossing.latitude %> / <%= crossing.longitude %>").openPopup();
+  <% end %>
 </script>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,0 +1,3 @@
+Rails.application.config.dartsass.builds = {
+  "application.scss" => "application.css",
+}


### PR DESCRIPTION
# 追加機能
- 踏切の位置情報を「都道府県」、「市町村」、「路線」ごとに検索
- 検索に応じて地図上に踏切のマーカーを表示

# 使用技術
- ransack：検索機能
- leaflet：地図表示

# 参考URL
- 【Rails】ransackを使って検索機能の実装  https://qiita.com/mmaumtjgj/items/8731a70b3f328770867c
- rails active recordで複数のテーブルをincludesするときの書き方お作法  https://qiita.com/makitokezuka/items/f13b2e7bad77b5594911
