### PR TITLE
踏切詳細ページの作成

### DIFF
--- a/app/controllers/crossings_controller.rb
+++ b/app/controllers/crossings_controller.rb
@@ -1,0 +1,17 @@
+class CrossingsController < ApplicationController
+  skip_before_action :require_login, only: %i[show]
+
+  def show
+    @crossing = Crossing.find(params[:id])
+
+    prefecture_id = CrossingPrefecture.find_by(crossing_id: @crossing.crossing_id).prefecture_id
+    @prefecture = Prefecture.find(prefecture_id)
+
+    city_id = CrossingCity.find_by(crossing_id: @crossing.crossing_id).city_id
+    @city = City.find(city_id)
+
+    railway_id = CrossingRailway.find_by(crossing_id: @crossing.crossing_id).railway_id
+    @railway = Railway.find(railway_id)
+  end
+
+end

--- a/app/controllers/map_pages_controller.rb
+++ b/app/controllers/map_pages_controller.rb
@@ -6,7 +6,7 @@ class MapPagesController < ApplicationController
     if params[:q].blank?
       @crossings = []  # params[:q]が空なら、検索結果は空
     else
-      @crossings = @q.result(distinct: true).includes(:linked_cities)
+      @crossings = @q.result(distinct: true).includes(:linked_prefectures, :linked_cities, :linked_railways)
     end
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,4 @@
+class PostsController < ApplicationController
+  def new
+  end
+end

--- a/app/decorators/crossing_decorator.rb
+++ b/app/decorators/crossing_decorator.rb
@@ -1,0 +1,13 @@
+class CrossingDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/decorators/post_decorator.rb
+++ b/app/decorators/post_decorator.rb
@@ -1,0 +1,13 @@
+class PostDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/views/crossings/show.html.erb
+++ b/app/views/crossings/show.html.erb
@@ -1,0 +1,12 @@
+<div class="container">
+  <div class="crossing-info">
+    <h2><%= @crossing.crossing_name %></h2>
+    <h4><%= @crossing.latitude %> / <%= @crossing.longitude %></h4>
+    <h4><%= @prefecture.prefecture_name %></h4>
+    <h4><%= @city.city_name %></h4>
+    <h4><%= @railway.railway_name %></h4>
+  </div>
+  <div>
+    <%= link_to '投稿', new_crossing_post_path(@crossing.crossing_id), class: 'btn btn-warning' %>
+  </div>
+</div>

--- a/app/views/map_pages/top.html.erb
+++ b/app/views/map_pages/top.html.erb
@@ -21,6 +21,6 @@
 
   // マーカーの追加（必要に応じて）
   <% @crossings.each do |crossing| %>
-    var marker = L.marker([<%= crossing.latitude %>, <%= crossing.longitude %>]).addTo(map).bindPopup("<%= crossing.latitude %> / <%= crossing.longitude %>").openPopup();
+    var marker = L.marker([<%= crossing.latitude %>, <%= crossing.longitude %>]).addTo(map).bindPopup('<%= link_to "詳細", crossing_path(crossing.crossing_id) %>').openPopup();
   <% end %>
 </script>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,23 @@
+<div class="container">
+  <div class="row">
+    <div class="col-lg-8 offset-lg-2">
+      <h2>新規投稿</h2>
+      <%= form_with model: @post do |f| %>
+      <div class="mb-3">
+        <%= f.label :title %>
+        <%= f.text_field :title, class: "form-control" %>
+      </div>
+      <div class="mb-3">
+        <%= f.label :body %>
+        <%= f.text_area :body, class: "form-control", rows: "10" %>
+      </div>
+      <div class="mb-3">
+        <%= f.label :image %>
+        <%= f.file_field :image, class: "form-control", accept: 'image/*' %>
+        <%= f.hidden_field :image_cache %>
+      </div>
+      <%= f.submit nil, class: "btn btn-primary" %>
+    <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,7 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
   # Defines the root path route ("/")
   # root "articles#index"
+  resources :crossings, only: %i[show] do
+    resources :posts, only: %i[new]
+  end
 end


### PR DESCRIPTION
## 追加機能
- 路線名での検索（前ブランチのやり忘れ）
- マップ上のポップアップ内に踏切詳細ページへのリンクを追加
- 詳細ページには踏切名、緯度・経度、都道府県名、市町村名、路線名を表示
- 詳細ページに新規投稿画面へのリンクを作成
- 新規投稿機能は、crossingリソースにpostリソースをネストする形でルーティングを設定
- posts_controller.rbにnewを追加