### PR TITLE
投稿詳細ページ作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 db_data/
 .DS_Store
+public/uploads/post/
 
 # Ignore bundler config.
 /.bundle

--- a/app/controllers/crossings_controller.rb
+++ b/app/controllers/crossings_controller.rb
@@ -2,16 +2,14 @@ class CrossingsController < ApplicationController
   skip_before_action :require_login, only: %i[show]
 
   def show
-    @crossing = Crossing.find(params[:id])
+    @crossing = Crossing.includes(:linked_prefectures, :linked_cities, :linked_railways, :posts).find(params[:id])
 
-    prefecture_id = CrossingPrefecture.find_by(crossing_id: @crossing.crossing_id).prefecture_id
-    @prefecture = Prefecture.find(prefecture_id)
+    @prefecture = @crossing.linked_prefectures.first
+    @city = @crossing.linked_cities.first
+    @railway = @crossing.linked_railways.first
 
-    city_id = CrossingCity.find_by(crossing_id: @crossing.crossing_id).city_id
-    @city = City.find(city_id)
-
-    railway_id = CrossingRailway.find_by(crossing_id: @crossing.crossing_id).railway_id
-    @railway = Railway.find(railway_id)
+    # crossingに該当するpostsをすべて取得
+    @posts = @crossing.posts.order(created_at: :desc)
   end
 
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,6 +15,16 @@ class PostsController < ApplicationController
     end
   end
 
+  def show
+    @crossing = Crossing.includes(:linked_prefectures, :linked_cities, :linked_railways, :posts).find(params[:crossing_id])
+
+    @prefecture = @crossing.linked_prefectures.first
+    @city = @crossing.linked_cities.first
+    @railway = @crossing.linked_railways.first
+
+    @post = Post.find(params[:id])
+  end
+
   private
 
   def post_params

--- a/app/views/crossings/show.html.erb
+++ b/app/views/crossings/show.html.erb
@@ -9,4 +9,15 @@
   <div>
     <%= link_to '投稿', new_crossing_post_path(@crossing.crossing_id), class: 'btn btn-warning' %>
   </div>
+  <%# 該当するpostデータをループさせてcardを表示する %>
+  <div class="post-index my-4">
+    <% @posts.each do |post| %>
+      <div class="card" style="width: 18rem;">
+        <%= image_tag post.crossing_image.url, class: "card-img-top" %>
+        <div class="card-body">
+          <%= link_to post.title, crossing_post_path(post.crossing_id, post.id), class: 'card-title' %>
+        </div>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,20 @@
+<div class="container">
+  <div class="crossing-info">
+    <h2><%= @crossing.crossing_name %></h2>
+    <h4><%= @crossing.latitude %> / <%= @crossing.longitude %></h4>
+    <h4><%= @prefecture.prefecture_name %></h4>
+    <h4><%= @city.city_name %></h4>
+    <h4><%= @railway.railway_name %></h4>
+  </div>
+  <div class="post-area">
+    <div class="crossing-image">
+      <%= image_tag @post.crossing_image.url, width: "500" %>
+    </div>
+    <div class="post-title">
+      <h3><%= @post.title %></h3>
+    </div>
+    <div class="post-body">
+      <p><%= @post.body %></p>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,6 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "articles#index"
   resources :crossings, only: %i[show] do
-    resources :posts, only: %i[new create]
+    resources :posts, only: %i[new create show]
   end
 end


### PR DESCRIPTION
## 追加機能
- 各踏切ページでその踏切の投稿を表示する
- 各投稿の詳細ページを作成
- postリソースにshowを追加
- postコントローラーにshowメソッドを追加
- views/posts/show.html.erbに投稿詳細ページを作成
- views/crossings/show.html.erbに投稿一覧表示を追加

## 参考URL
- 2.7 ネストしたリソース 
https://railsguides.jp/routing.html#%E3%83%8D%E3%82%B9%E3%83%88%E3%81%97%E3%81%9F%E3%83%AA%E3%82%BD%E3%83%BC%E3%82%B9
- 【Rails】ネストしたルーティングのURLのidが入れ替わる問題への対処法  
https://plog.kobacchi.com/rails-nested-routes-url-id/
- カード(bootstrap)  
https://getbootstrap.jp/docs/5.3/components/card/