### PR TITLE
本番環境におけるCloudinaryへの画像アップロード

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 db_data/
 .DS_Store
 public/uploads/post/
+/.env
 
 # Ignore bundler config.
 /.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,10 @@ gem 'leaflet-rails'
 
 gem 'leaflet-markercluster-rails'
 
+gem 'cloudinary'
+
+gem 'dotenv-rails'
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.8", ">= 7.0.8.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,11 @@ GEM
       marcel (~> 1.0.0)
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
+    cloudinary (2.2.0)
+      faraday (>= 2.0.1, < 3.0.0)
+      faraday-follow_redirects (~> 0.3.0)
+      faraday-multipart (~> 1.0, >= 1.0.4)
+      ostruct
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     config (5.5.2)
@@ -127,6 +132,10 @@ GEM
     debug_inspector (1.2.0)
     deep_merge (1.2.2)
     diff-lcs (1.5.1)
+    dotenv (3.1.4)
+    dotenv-rails (3.1.4)
+      dotenv (= 3.1.4)
+      railties (>= 6.1)
     draper (4.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -149,6 +158,10 @@ GEM
       faraday-net_http (>= 2.0, < 3.4)
       json
       logger
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
     faraday-net_http (3.3.0)
       net-http
     ffi (1.17.0-aarch64-linux-gnu)
@@ -216,6 +229,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
+    multipart-post (2.4.1)
     net-http (0.4.1)
       uri
     net-imap (0.4.16)
@@ -412,9 +426,11 @@ DEPENDENCIES
   bootstrap5-kaminari-views
   capybara
   carrierwave (= 2.2.2)
+  cloudinary
   config
   dartsass-rails (~> 0.4.0)
   debug
+  dotenv-rails
   draper (= 4.0.2)
   enum_help
   factory_bot_rails

--- a/app/controllers/crossings_controller.rb
+++ b/app/controllers/crossings_controller.rb
@@ -8,8 +8,8 @@ class CrossingsController < ApplicationController
     @city = @crossing.linked_cities.first
     @railway = @crossing.linked_railways.first
 
-    # crossingに該当するpostsをすべて取得
     @posts = @crossing.posts.order(created_at: :desc)
+
   end
 
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,7 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.build(post_params)
     if @post.save
-      redirect_to root_path
+      redirect_to crossing_path(params[:crossing_id])
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/uploaders/crossing_image_uploader.rb
+++ b/app/uploaders/crossing_image_uploader.rb
@@ -2,7 +2,9 @@ class CrossingImageUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
   # include CarrierWave::MiniMagick
-
+  if Rails.env.production?
+    include Cloudinary::CarrierWave
+  end
   # Choose what kind of storage to use for this uploader:
   storage :file
   # storage :fog

--- a/app/views/crossings/show.html.erb
+++ b/app/views/crossings/show.html.erb
@@ -11,13 +11,18 @@
   </div>
   <%# 該当するpostデータをループさせてcardを表示する %>
   <div class="post-index my-4">
-    <% @posts.each do |post| %>
-      <div class="card" style="width: 18rem;">
-        <%= image_tag post.crossing_image.url, class: "card-img-top" %>
-        <div class="card-body">
-          <%= link_to post.title, crossing_post_path(post.crossing_id, post.id), class: 'card-title' %>
+    <div class="d-flex">
+      <% @posts.each do |post| %>
+        <div class="mb-3 px-3">
+          <div class="card" style="width: 18rem;">
+            <%= image_tag post.crossing_image.url, class: "card-img-top" %>
+            <div class="card-body">
+              <%= link_to post.title, crossing_post_path(post.crossing_id, post.id), class: 'card-title' %>
+              <p><%= post.user.name %></p>
+            </div>
+          </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -6,15 +6,17 @@
     <h4><%= @city.city_name %></h4>
     <h4><%= @railway.railway_name %></h4>
   </div>
-  <div class="post-area">
+  <div class="post-area d-flex justify-content-around">
     <div class="crossing-image">
       <%= image_tag @post.crossing_image.url, width: "500" %>
     </div>
-    <div class="post-title">
-      <h3><%= @post.title %></h3>
-    </div>
-    <div class="post-body">
-      <p><%= @post.body %></p>
+    <div class="post-info">
+      <div class="post-title">
+        <h3><%= @post.title %></h3>
+      </div>
+      <div class="post-body">
+        <p><%= @post.body %></p>
+      </div>
     </div>
   </div>
 </div>

--- a/config/cloudinary.yml
+++ b/config/cloudinary.yml
@@ -1,0 +1,19 @@
+---
+development:
+  cloud_name: ENV['CLOUDINARY_CLOUD_NAME']
+  api_key: ENV['CLOUDINARY_API_KEY']
+  api_secret: ENV['CLOUDINARY_API_SECRET']
+  enhance_image_tag: true
+  static_image_support: false
+production:
+  cloud_name: ENV['CLOUDINARY_CLOUD_NAME']
+  api_key: ENV['CLOUDINARY_API_KEY']
+  api_secret: ENV['CLOUDINARY_API_SECRET']
+  enhance_image_tag: true
+  static_image_support: true
+test:
+  cloud_name: ENV['CLOUDINARY_CLOUD_NAME']
+  api_key: ENV['CLOUDINARY_API_KEY']
+  api_secret: ENV['CLOUDINARY_API_SECRET']
+  enhance_image_tag: true
+  static_image_support: false


### PR DESCRIPTION
## 追加機能
- 踏切詳細ページの投稿一覧の見た目を整える
- 本番環境においてCloudinaryを使用してアップロードされた画像を保存する

## 使用技術
- gem 'cloudinary'
- gem 'dotenv-rails'（環境変数設定）

## 参考URL
- Rails + cloudinary + carrier wave 画像アップロードアプリのテスト  
https://qiita.com/ntkgcj/items/6ca19c9decf929714970
- Cloudinary + Carrierwave + Heroku + Railsでの画像を手軽に利用する方法  
https://qiita.com/GenTamura84/items/38cf899827bba050a21c
- Cloudinary + Rails 画像アップロード  
https://qiita.com/ttexan/items/a1004121e806c477d030
- heroku × Railsでメディア運営をする（Cloudinary編）  
https://nimi0370376.hatenablog.com/entry/2017/09/14/014644
- Rails 環境変数の定義  
https://zenn.dev/goldsaya/articles/8614854f00bb98