### PR TITLE
投稿一覧ページの作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,10 @@
 class PostsController < ApplicationController
   before_action :require_login, only: %i[new create]
 
+  def index
+    @posts = Post.all.order(created_at: :desc)
+  end
+
   def new
     @crossing = Crossing.find(params[:crossing_id])
     @post = Post.new

--- a/app/views/crossings/show.html.erb
+++ b/app/views/crossings/show.html.erb
@@ -4,31 +4,5 @@
     <%= link_to '投稿', new_crossing_post_path(@crossing.crossing_id), class: 'btn btn-warning' %>
   </div>
   <%# 投稿一覧 %>
-  <div class="post-index my-4">
-    <div class="d-flex flex-wrap">
-      <% @posts.each do |post| %>
-        <div class="mb-3 px-3" id="post-id-<%= post.id %>">
-          <div class="card" style="width: 18rem;">
-            <%= image_tag post.crossing_image.url, class: "card-img-top" %>
-            <div class="card-body">
-              <%= link_to post.title, crossing_post_path(post.crossing_id, post.id), class: 'card-title' %>
-              <div class="d-flex">
-                <p><%= post.user.name %></p>
-                <% if current_user && current_user.own?(post) %>
-                  <div class='ms-auto'>
-                    <%= link_to edit_crossing_post_path(post.crossing_id, post.id), class: "btn btn-link p-0", id: "button-edit-#{post.id}" do %>
-                      <i class="bi bi-pen-fill"></i>
-                    <% end %>
-                    <%= link_to crossing_post_path(post.crossing_id, post.id), class: "btn btn-link p-0", id: "button-delete-#{post.id}", data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' } do %>
-                      <i class="bi bi-trash3-fill"></i>
-                    <% end %>
-                  </div>
-                <% end %>
-              </div>
-            </div>
-          </div>
-        </div>
-      <% end %>
-    </div>
-  </div>
+  <%= render 'shared/post', posts: @posts %>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,4 @@
+<div class="container">
+  <h2>投稿一覧</h2>
+  <%= render 'shared/post', posts: @posts %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,7 +10,7 @@
     <div class='collapse navbar-collapse' id='navbarSupportedContent'>
       <ul class='navbar-nav ms-auto main-nav align-items-center'>
         <li class='nav-item'>
-          <%= link_to '投稿一覧', '#', class: 'nav-link' %>
+          <%= link_to '投稿一覧', posts_path, class: 'nav-link' %>
         </li>
 
         <li class='nav-item dropdown dropdown-slide'>

--- a/app/views/shared/_post.html.erb
+++ b/app/views/shared/_post.html.erb
@@ -1,0 +1,27 @@
+<div class="post-index my-4">
+    <div class="d-flex flex-wrap">
+      <% posts.each do |post| %>
+        <div class="mb-3 px-3" id="post-id-<%= post.id %>">
+          <div class="card" style="width: 18rem;">
+            <%= image_tag post.crossing_image.url, class: "card-img-top" %>
+            <div class="card-body">
+              <%= link_to post.title, crossing_post_path(post.crossing_id, post.id), class: 'card-title' %>
+              <div class="d-flex">
+                <p><%= post.user.name %></p>
+                <% if current_user && current_user.own?(post) %>
+                  <div class='ms-auto'>
+                    <%= link_to edit_crossing_post_path(post.crossing_id, post.id), class: "btn btn-link p-0", id: "button-edit-#{post.id}" do %>
+                      <i class="bi bi-pen-fill"></i>
+                    <% end %>
+                    <%= link_to crossing_post_path(post.crossing_id, post.id), class: "btn btn-link p-0", id: "button-delete-#{post.id}", data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' } do %>
+                      <i class="bi bi-trash3-fill"></i>
+                    <% end %>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
   # Defines the root path route ("/")
   # root "articles#index"
+  resources :posts, only: %i[index]
+
   resources :crossings, only: %i[show] do
     resources :posts, only: %i[new create show edit update destroy] do
       resources :comments, only: %i[create edit destroy]


### PR DESCRIPTION
## 追加事項
- crossingリソースにネストされていないpostリソースを作成（indexのみ）
- posts_controllerにindexアクションを追加
- 投稿一覧表示部分をshared/_post.html.erbに作成
- crossings/show.html.erbとposts/index.html.erbの投稿一覧部分をshared/_post.html.erbを利用する形に変更