### PR TITLE
投稿一覧ページに検索フォームを追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,8 +1,9 @@
 class PostsController < ApplicationController
-  before_action :require_login, only: %i[new create]
+  before_action :require_login, only: %i[new create edit update destroy]
 
   def index
-    @posts = Post.all.order(created_at: :desc)
+    @q = Post.ransack(params[:q])
+    @posts = @q.result(distinct: true).includes(crossing: [:linked_prefectures, :linked_cities, :linked_railways], user:[]).order(created_at: :desc)
   end
 
   def new

--- a/app/views/map_pages/top.html.erb
+++ b/app/views/map_pages/top.html.erb
@@ -1,11 +1,11 @@
 <div class="position-relative">
   <div class="search_form position-absolute top-0 start-50 translate-middle-x z-1">
     <%= form_with model: @q, scope: :q, url: root_path, method: :get, class: 'd-flex justify-content-evenly p-2' do |f| %>
-    <%= f.select :linked_prefectures_prefecture_id_eq, Prefecture.pluck(:prefecture_name, :prefecture_id), { include_blank: '都道府県' }, class: 'form-select shadow m-2' %>
-    <%= f.select :linked_cities_city_id_eq, City.pluck(:city_name, :city_id), { include_blank: '市町村' }, class: 'form-select shadow m-2' %>
-    <%= f.select :linked_railways_railway_id_eq, Railway.pluck(:railway_name, :railway_id), { include_blank: '路線' }, class: 'form-select shadow m-2' %>
-    <%= f.submit '検索', class: 'btn btn-warning shadow m-2' %>
-  <% end %>
+      <%= f.select :linked_prefectures_prefecture_id_eq, Prefecture.pluck(:prefecture_name, :prefecture_id), { include_blank: '都道府県' }, class: 'form-select shadow m-2' %>
+      <%= f.select :linked_cities_city_id_eq, City.pluck(:city_name, :city_id), { include_blank: '市町村' }, class: 'form-select shadow m-2' %>
+      <%= f.select :linked_railways_railway_id_eq, Railway.pluck(:railway_name, :railway_id), { include_blank: '路線' }, class: 'form-select shadow m-2' %>
+      <%= f.submit '検索', class: 'btn btn-warning shadow m-2' %>
+    <% end %>
   </div>
   <div class="z-0" id="map" style="width: 100%; height: 800px;"></div>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,13 @@
 <div class="container">
   <h2>投稿一覧</h2>
+  <div class="search_form">
+    <%= form_with model: @q, scope: :q, url: posts_path, method: :get, class: 'd-flex justify-content-evenly p-2' do |f| %>
+      <%= f.select :crossing_linked_prefectures_prefecture_id_eq, Prefecture.pluck(:prefecture_name, :prefecture_id), { include_blank: '都道府県' }, class: 'form-select shadow m-2' %>
+      <%= f.select :crossing_linked_cities_city_id_eq, City.pluck(:city_name, :city_id), { include_blank: '市町村' }, class: 'form-select shadow m-2' %>
+      <%= f.select :crossing_linked_railways_railway_id_eq, Railway.pluck(:railway_name, :railway_id), { include_blank: '路線' }, class: 'form-select shadow m-2' %>
+      <%= f.search_field :user_name_or_title_or_body_cont, class: 'form-control shadow m-2', placeholder: '検索ワード' %>
+      <%= f.submit '検索', class: 'btn btn-warning shadow m-2' %>
+    <% end %>
+  </div>
   <%= render 'shared/post', posts: @posts %>
 </div>


### PR DESCRIPTION
## 追加機能
- views/posts/index.html.erbに検索フォームを追加
- controllers/posts_controller.rbのindexアクションをransackを利用する形に編集
- 都道府県、市町村、路線での検索
- 投稿者・タイトル・本文のフリーワード検索

## 参考URL
- モデル関連の階層が2層以上ある場合のincludes設定  
https://qiita.com/blueplanet/items/05aa424cc7e5847e6c84