### PR TITLE
タグ投稿機能とタグ絞り込み機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem 'image_processing', '~> 1.2'
 
 gem 'mini_magick'
 
+gem 'acts-as-taggable-on'
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.8", ">= 7.0.8.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,9 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    acts-as-taggable-on (11.0.0)
+      activerecord (>= 7.0, < 8.0)
+      zeitwerk (>= 2.4, < 3.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
@@ -443,6 +446,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  acts-as-taggable-on
   better_errors
   binding_of_caller
   bootsnap

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,6 +4,10 @@ class PostsController < ApplicationController
   def index
     @q = Post.ransack(params[:q])
     @posts = @q.result(distinct: true).includes(crossing: [city: [:prefecture], linked_railways:[]], user:[]).order(created_at: :desc)
+    @tags = Post.tag_counts_on(:tags).most_used(20)
+    if params[:tag_name]
+      @posts = Post.tagged_with("#{params[:tag_name]}")
+    end
   end
 
   def new
@@ -40,6 +44,7 @@ class PostsController < ApplicationController
   def show
     @crossing = Crossing.includes(city: [:prefecture], linked_railways:[], posts:[]).find(params[:crossing_id])
     @post = Post.find(params[:id])
+    @tags = @post.tag_counts_on(:tags)
     @favorites = @post.favorites
     @comment = Comment.new
     @comments = @post.comments.includes(:user).order(created_at: :desc)
@@ -54,6 +59,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :body, :crossing_image, :crossing_image_cache).merge(crossing_id: params[:crossing_id])
+    params.require(:post).permit(:title, :body, :crossing_image, :crossing_image_cache, :tag_list).merge(crossing_id: params[:crossing_id])
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -13,4 +13,6 @@ class Post < ApplicationRecord
   end
 
   mount_uploader :crossing_image, CrossingImageUploader
+
+  acts_as_taggable_on :tags
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -8,6 +8,10 @@
     <%= f.text_area :body, class: "form-control", rows: "10" %>
   </div>
   <div class="mb-3">
+    <%= f.label :tag_list %>
+    <%= f.text_field :tag_list, value: @post.tag_list.join(','), class: "form-control", id:'post_tag_list', placeholder: "タグをつける。複数つけるには「,」で区切ってください。" %>
+  </div>
+  <div class="mb-3">
     <%= f.label :crossing_image %>
     <%= f.file_field :crossing_image, class: "form-control", accept: 'image/*' %>
     <%= f.hidden_field :crossing_image_cache %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,5 +9,12 @@
       <%= f.submit '検索', class: 'btn btn-warning shadow m-2' %>
     <% end %>
   </div>
+  <div class="tag-list">
+    <% @tags.each do |tag| %>
+      <span class="badge badge-info mr-2 mb-2">
+        <%= link_to "#{tag.name}(#{tag.taggings_count})", posts_path(tag_name: tag.name) %>
+      </span>
+    <% end %>
+  </div>
   <%= render 'shared/post', posts: @posts %>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,6 +8,13 @@
       <div class="post-title">
         <h3><%= @post.title %></h3>
       </div>
+      <div class="tag-list">
+        <% @tags.each do |tag| %>
+          <span class="badge badge-info mr-2 mb-2">
+            <%= link_to "#{tag.name}(#{tag.taggings_count})", posts_path(tag_name: tag.name) %>
+          </span>
+        <% end %>
+      </div>
       <div>
         <% if current_user && current_user.own?(@post) %>
           <div class='ms-auto'>

--- a/app/views/shared/_post.html.erb
+++ b/app/views/shared/_post.html.erb
@@ -1,27 +1,32 @@
 <div class="post-index my-4">
-    <div class="d-flex flex-wrap">
-      <% posts.each do |post| %>
-        <div class="mb-3 px-3" id="post-id-<%= post.id %>">
-          <div class="card" style="width: 18rem;">
-            <%= image_tag post.crossing_image.url, class: "card-img-top" %>
-            <div class="card-body">
-              <%= link_to post.title, crossing_post_path(post.crossing_id, post.id), class: 'card-title' %>
-              <div class="d-flex">
-                <p><%= post.user.name %></p>
-                <% if current_user && current_user.own?(post) %>
-                  <div class='ms-auto'>
-                    <%= link_to edit_crossing_post_path(post.crossing_id, post.id), class: "btn btn-link p-0", id: "button-edit-#{post.id}" do %>
-                      <i class="bi bi-pen-fill"></i>
-                    <% end %>
-                    <%= link_to crossing_post_path(post.crossing_id, post.id), class: "btn btn-link p-0", id: "button-delete-#{post.id}", data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' } do %>
-                      <i class="bi bi-trash3-fill"></i>
-                    <% end %>
-                  </div>
-                <% end %>
-              </div>
+  <div class="d-flex flex-wrap">
+    <% posts.each do |post| %>
+      <div class="mb-3 px-3" id="post-id-<%= post.id %>">
+        <div class="card" style="width: 18rem;">
+          <%= image_tag post.crossing_image.url, class: "card-img-top" %>
+          <div class="card-body">
+            <%= link_to post.title, crossing_post_path(post.crossing_id, post.id), class: 'card-title' %>
+            <div class="d-flex">
+              <p><%= post.user.name %></p>
+              <% if current_user && current_user.own?(post) %>
+                <div class='ms-auto'>
+                  <%= link_to edit_crossing_post_path(post.crossing_id, post.id), class: "btn btn-link p-0", id: "button-edit-#{post.id}" do %>
+                    <i class="bi bi-pen-fill"></i>
+                  <% end %>
+                  <%= link_to crossing_post_path(post.crossing_id, post.id), class: "btn btn-link p-0", id: "button-delete-#{post.id}", data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' } do %>
+                    <i class="bi bi-trash3-fill"></i>
+                  <% end %>
+                </div>
+              <% end %>
             </div>
+            <% post.tag_list.each do |tag| %>
+              <span class="badge badge-info mr-2 mb-2">
+                <%= link_to "#{tag}", posts_path(tag_name: tag) %>
+              </span>
+            <% end %>
           </div>
         </div>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   </div>
+</div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -13,6 +13,7 @@ ja:
       post:
         title: タイトル
         body: 本文
+        tag_list: タグ
         crossing_image: フミキリフォト
         created_at: 作成日時
       comment:

--- a/db/migrate/20241231223656_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20241231223656_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20241231223657_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20241231223657_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+class AddMissingUniqueIndices < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20241231223658_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20241231223658_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20241231223659_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20241231223659_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+class AddMissingTaggableIndex < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20241231223660_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20241231223660_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+
+class ChangeCollationForTagNames < ActiveRecord::Migration[6.0]
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20241231223661_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20241231223661_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+class AddMissingIndexesOnTaggings < ActiveRecord::Migration[6.0]
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                 :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                   :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                               :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                         name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                name: 'taggings_idy'
+    end
+  end
+end

--- a/db/migrate/20241231223662_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20241231223662_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 7)
+class AddTenantToTaggings < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.taggings_table, :tenant, :string, limit: 128
+    add_index ActsAsTaggableOn.taggings_table, :tenant unless index_exists? ActsAsTaggableOn.taggings_table, :tenant
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, :tenant
+    remove_column ActsAsTaggableOn.taggings_table, :tenant
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_29_224039) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_31_223662) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -78,6 +78,37 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_29_224039) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "taggings", force: :cascade do |t|
+    t.bigint "tag_id"
+    t.string "taggable_type"
+    t.bigint "taggable_id"
+    t.string "tagger_type"
+    t.bigint "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at", precision: nil
+    t.string "tenant", limit: 128
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+    t.index ["tagger_type", "tagger_id"], name: "index_taggings_on_tagger_type_and_tagger_id"
+    t.index ["tenant"], name: "index_taggings_on_tenant"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "crypted_password"
@@ -101,4 +132,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_29_224039) do
   add_foreign_key "crossings", "cities", primary_key: "city_id"
   add_foreign_key "posts", "crossings", primary_key: "crossing_id"
   add_foreign_key "posts", "users"
+  add_foreign_key "taggings", "tags"
 end


### PR DESCRIPTION
## 追加機能
- タグ投稿
- タグでの絞り込み
各投稿や投稿一覧ページに表されているタグをクリックすると、そのタグが登録されている投稿一覧を表示することが出来る。

## 使用gem等
-gem 'acts-as-taggable-on'

## 参考URL
- acts-as-taggable-on
https://github.com/mbleigh/acts-as-taggable-on
- 【Rails】gem:acts-as-taggable-on と Bootstrap Tags Input を使ったタグ機能① 実装編
https://zenn.dev/ganmo3/articles/25b8bfdfb09ce7
- 【Rails】タグ管理機能(acts-as-taggable-on使用)
https://qiita.com/manbolila/items/3f178b7698d877a29b12
- Rails | acts-as-taggable-on を使ったタグ機能の実装 | 備忘録
https://qiita.com/d510/items/e1caa8b73d118822a0a2
- 【rails】gemを使ってタグ機能を実装する
https://qiita.com/iwasan06/items/9d8e052a5866a0074504