### PR TITLE
gem meta-tagを利用したOGPの設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem 'high_voltage'
 
 gem 'redcarpet'
 
+gem 'meta-tags'
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.8", ">= 7.0.8.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,8 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    meta-tags (2.22.1)
+      actionpack (>= 6.0.0, < 8.1)
     method_source (1.1.0)
     mime-types (3.6.0)
       logger
@@ -479,6 +481,7 @@ DEPENDENCIES
   leaflet-markercluster-rails
   leaflet-rails
   letter_opener_web (~> 3.0)
+  meta-tags
   mini_magick
   pg
   pry

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,26 @@ module ApplicationHelper
     markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
     markdown.render(Rails.root.join('service_terms.md').read)
   end
+
+  def default_meta_tags
+    {
+      site: 'フミキリのちず',
+      title: '踏切の位置検索と写真投稿',
+      reverse: true,
+      charset: 'utf-8',
+      description: '踏切の位置情報の検索と踏切の写真投稿ができるWEBサイト',
+      keywords: '踏切,電車,地図',
+      canonical: request.original_url,
+      separator: '|',
+      og: {
+        site_name: :site,
+        title: :title,
+        description: :description,
+        type: 'website',
+        url: request.original_url,
+        image: image_url('仮ogp.jpg'),
+        local: 'ja-JP'
+      }
+    }
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,13 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>RailroadCrossingApp</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta property="og:title" content="踏切の位置検索と写真投稿【フミキリのちず】">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://railroad-crossing-app-eb89cd3a3946.herokuapp.com">
-    <meta property="og:image" content="<%= asset_url('仮ogp.jpg') %>">
-    <meta property="og:site_name" content="踏切の位置検索と写真投稿【フミキリのちず】">
+    <title>フミキリのちす</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -18,6 +12,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
     <%= javascript_importmap_tags %>
+    <%= display_meta_tags(default_meta_tags) %>
     
   </head>
 

--- a/config/initializers/meta_tags.rb
+++ b/config/initializers/meta_tags.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Use this setup block to configure all options available in MetaTags.
+MetaTags.configure do |config|
+  # How many characters should the title meta tag have at most. Default is 70.
+  # Set to nil or 0 to remove limits.
+  # config.title_limit = 70
+
+  # When true, site title will be truncated instead of title. Default is false.
+  # config.truncate_site_title_first = false
+
+  # Add HTML attributes to the <title> HTML tag. Default is {}.
+  # config.title_tag_attributes = {}
+
+  # Natural separator when truncating. Default is " " (space character).
+  # Set to nil to disable natural separator.
+  # This also allows you to use a whitespace regular expression (/\s/) or
+  # a Unicode space (/\p{Space}/).
+  # config.truncate_on_natural_separator = " "
+
+  # Maximum length of the page description. Default is 300.
+  # Set to nil or 0 to remove limits.
+  # config.description_limit = 300
+
+  # Maximum length of the keywords meta tag. Default is 255.
+  # config.keywords_limit = 255
+
+  # Default separator for keywords meta tag (used when an Array passed with
+  # the list of keywords). Default is ", ".
+  # config.keywords_separator = ', '
+
+  # When true, keywords will be converted to lowercase, otherwise they will
+  # appear on the page as is. Default is true.
+  # config.keywords_lowercase = true
+
+  # When true, the output will not include new line characters between meta tags.
+  # Default is false.
+  # config.minify_output = false
+
+  # When false, generated meta tags will be self-closing (<meta ... />) instead
+  # of open (`<meta ...>`). Default is true.
+  # config.open_meta_tags = true
+
+  # List of additional meta tags that should use "property" attribute instead
+  # of "name" attribute in <meta> tags.
+  # config.property_tags.push(
+  #   'x-hearthstone:deck',
+  # )
+end


### PR DESCRIPTION
## 追加機能
- OGPの設定
- gem 'meta-tag'を利用してapplication.hgtml.erbにmetaタグを設定する。

## 使用gem
gem 'meta-tag'

## 参考URL
- meta-tags
https://github.com/kpumuk/meta-tags
- [Rails] metaタグを設定する方法
https://qiita.com/momo1010/items/ccb507c013976846a549
- [Rails]OGPの設定方法と、Local環境での確認方法[meta-tags]
https://zenn.dev/yoshiki105/articles/eb093bf603e728
- OGPとは？画像サイズや設定方法、確認ツールをご紹介
https://www.atoj.co.jp/atoj-info/detail/62