### PR TITLE
現在地情報を利用した踏切検索

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,12 @@ gem 'redcarpet'
 
 gem 'meta-tags'
 
+gem 'geokit'
+
+gem 'geokit-rails'
+
+gem 'gon'
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.8", ">= 7.0.8.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,8 +180,17 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.1.0)
+    geokit (1.14.0)
+    geokit-rails (2.5.0)
+      geokit (~> 1.5)
+      rails (>= 3.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
     hashie (5.0.0)
     high_voltage (4.0.0)
     i18n (1.14.6)
@@ -472,6 +481,9 @@ DEPENDENCIES
   factory_bot_rails
   faker
   fog-aws
+  geokit
+  geokit-rails
+  gon
   high_voltage
   image_processing (~> 1.2)
   importmap-rails

--- a/app/controllers/map_pages_controller.rb
+++ b/app/controllers/map_pages_controller.rb
@@ -2,11 +2,28 @@ class MapPagesController < ApplicationController
   skip_before_action :require_login, only: %i[top]
 
   def top
-    @q = Crossing.ransack(params[:q])
-    if params[:q].blank?
-      @crossings = [] # params[:q]が空なら、検索結果は空
+    lat = params[:latitude].to_f
+    lon = params[:longitude].to_f
+
+    if lat.present? && lon.present? && lat != 0.0 && lon != 0.0
+      @crossings = Crossing.within(2, origin: [lat, lon]).includes(city: [:prefecture], linked_railways: [])
     else
-      @crossings = @q.result(distinct: true).includes(city: [:prefecture], linked_railways: [])
+      @q = Crossing.ransack(params[:q])
+      if params[:q].blank?
+        @crossings = [] # params[:q]が空なら、検索結果は空
+      else
+        @crossings = @q.result(distinct: true).includes(city: [:prefecture], linked_railways: [])
+      end
     end
+
+    #@q = Crossing.ransack(params[:q])
+
+    #if params[:q].blank?
+    #  @crossings = [] # params[:q]が空なら、検索結果は空
+    #elsif lat.present? && lon.present?
+    #  @crossings = Crossing.within(2, origin: [lat, lon])
+    #else
+    #  @crossings = @q.result(distinct: true).includes(city: [:prefecture], linked_railways: [])
+    #end
   end
 end

--- a/app/models/crossing.rb
+++ b/app/models/crossing.rb
@@ -7,4 +7,6 @@ class Crossing < ApplicationRecord
   has_many :linked_railways, through: :crossing_railways, source: :railway
 
   has_many :posts, dependent: :destroy, foreign_key: :crossing_id, primary_key: :crossing_id, inverse_of: :crossing
+
+  acts_as_mappable default_units: :kms, lat_column_name: :latitude, lng_column_name: :longitude
 end

--- a/app/views/map_pages/top.html.erb
+++ b/app/views/map_pages/top.html.erb
@@ -6,21 +6,37 @@
       <%= f.select :linked_railways_railway_id_eq, Railway.pluck(:railway_name, :railway_id), { include_blank: '路線' }, class: 'form-select shadow m-2' %>
       <%= f.submit '検索', class: 'btn btn-warning shadow m-2' %>
     <% end %>
+    <div class="current-location">
+      <button id="get-location-btn" class="btn btn-primary">近くのフミキリ</button>
+    </div>
   </div>
   <div class="z-0" id="map" style="width: 100%; height: 800px;"></div>
 </div>
 
 <script>
-  // 地図の初期設定
-  var map = L.map('map').setView([35.6895, 139.6917], 13);  // 東京の緯度経度を指定
+//OpenStreetMapの表示
+  var map = L.map('map').setView([35.6895, 139.6917], 13);  //東京
 
-  // OSMタイルレイヤーを追加
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
   }).addTo(map);
 
-  // マーカーの追加（必要に応じて）
   <% @crossings.each do |crossing| %>
     var marker = L.marker([<%= crossing.latitude %>, <%= crossing.longitude %>]).addTo(map).bindPopup('<%= link_to "詳細", crossing_path(crossing.crossing_id) %>').openPopup();
   <% end %>
+
+//現在地の取得と反映
+  document.getElementById("get-location-btn").onclick = function(){
+    navigator.geolocation.getCurrentPosition(successCallback, errorCallback);
+  };
+
+  function successCallback(position){
+    var latitude = position.coords.latitude;
+    var longitude = position.coords.longitude;
+    window.location.href = `/?latitude=${latitude}&longitude=${longitude}`;
+  };
+
+  function errorCallback(error){
+      alert("位置情報が取得できませんでした");
+  };
 </script>

--- a/config/initializers/geokit_config.rb
+++ b/config/initializers/geokit_config.rb
@@ -1,0 +1,100 @@
+# These defaults are used in Geokit::Mappable.distance_to and acts_as_mappable
+Geokit::default_units = :miles # others :kms, :nms, :meters
+Geokit::default_formula = :sphere
+
+# This is the timeout value in seconds to be used for calls to the geocoder web
+# services.  For no timeout at all, comment out the setting.  The timeout unit
+# is in seconds.
+Geokit::Geocoders::request_timeout = 3
+
+# This setting can be used if web service calls must be routed through a proxy.
+# These setting can be nil if not needed, otherwise, a valid URI must be
+# filled in at a minimum.  If the proxy requires authentication, the username
+# and password can be provided as well.
+# Geokit::Geocoders::proxy = 'https://user:password@host:port'
+
+# This is your yahoo application key for the Yahoo Geocoder.
+# See http://developer.yahoo.com/faq/index.html#appid
+# and http://developer.yahoo.com/maps/rest/V1/geocode.html
+# Geokit::Geocoders::YahooGeocoder.key = 'REPLACE_WITH_YOUR_YAHOO_KEY'
+# Geokit::Geocoders::YahooGeocoder.secret = 'REPLACE_WITH_YOUR_YAHOO_SECRET'
+
+# This is your Google Maps geocoder keys (all optional).
+# See http://www.google.com/apis/maps/signup.html
+# and http://www.google.com/apis/maps/documentation/#Geocoding_Examples
+# Geokit::Geocoders::GoogleGeocoder.client_id = ''
+# Geokit::Geocoders::GoogleGeocoder.cryptographic_key = ''
+# Geokit::Geocoders::GoogleGeocoder.channel = ''
+
+# You can also use the free API key instead of signed requests
+# See https://developers.google.com/maps/documentation/geocoding/#api_key
+# Geokit::Geocoders::GoogleGeocoder.api_key = ''
+
+# You can also set multiple API KEYS for different domains that may be directed
+# to this same application.
+# The domain from which the current user is being directed will automatically
+# be updated for Geokit via
+# the GeocoderControl class, which gets it's begin filter mixed
+# into the ActionController.
+# You define these keys with a Hash as follows:
+# Geokit::Geocoders::google = {
+# 'rubyonrails.org' => 'RUBY_ON_RAILS_API_KEY',
+# ' ruby-docs.org' => 'RUBY_DOCS_API_KEY' }
+
+# This is your username and password for geocoder.us.
+# To use the free service, the value can be set to nil or false.  For
+# usage tied to an account, the value should be set to username:password.
+# See http://geocoder.us
+# and http://geocoder.us/user/signup
+# Geokit::Geocoders::UsGeocoder.key = 'username:password'
+
+# This is your authorization key for geocoder.ca.
+# To use the free service, the value can be set to nil or false.  For
+# usage tied to an account, set the value to the key obtained from
+# Geocoder.ca.
+# See http://geocoder.ca
+# and http://geocoder.ca/?register=1
+# Geokit::Geocoders::CaGeocoder.key = 'KEY'
+
+# This is your username key for geonames.
+# To use this service either free or premium, you must register a key.
+# See http://www.geonames.org
+# Geokit::Geocoders::GeonamesGeocoder.key = 'KEY'
+
+# Most other geocoders need either no setup or a key
+# Geokit::Geocoders::BingGeocoder.key = ''
+# Geokit::Geocoders::MapQuestGeocoder.key = ''
+# Geokit::Geocoders::YandexGeocoder.key = ''
+# Geokit::Geocoders::MapboxGeocoder.key = 'ACCESS_TOKEN'
+# Geokit::Geocoders::OpencageGeocoder.key = 'some_api_key'
+
+# Geonames has a free service and a premium service, each using a different URL
+# GeonamesGeocoder.premium = true will use http://ws.geonames.net (premium)
+# GeonamesGeocoder.premium = false will use http://api.geonames.org (free)
+# Geokit::Geocoders::GeonamesGeocoder.premium = false
+
+# require "external_geocoder.rb"
+# Please see the section "writing your own geocoders" for more information.
+# Geokit::Geocoders::external_key = 'REPLACE_WITH_YOUR_API_KEY'
+
+# This is the order in which the geocoders are called in a failover scenario
+# If you only want to use a single geocoder, put a single symbol in the array.
+# Valid symbols are :google, :yahoo, :us, and :ca.
+# Be aware that there are Terms of Use restrictions on how you can use the
+# various geocoders.  Make sure you read up on relevant Terms of Use for each
+# geocoder you are going to use.
+# Geokit::Geocoders::provider_order = [:google,:us]
+
+# The IP provider order. Valid symbols are :ip,:geo_plugin.
+# As before, make sure you read up on relevant Terms of Use for each.
+# Geokit::Geocoders::ip_provider_order = [:external,:geo_plugin,:ip]
+
+# Disable HTTPS globally.  This option can also be set on individual
+# geocoder classes.
+# Geokit::Geocoders::secure = false
+
+# Control verification of the server certificate for geocoders using HTTPS
+# Geokit::Geocoders::ssl_verify_mode = OpenSSL::SSL::VERIFY_(PEER/NONE)
+# Setting this to VERIFY_NONE may be needed on systems that don't have
+# a complete or up to date root certificate store. Only applies to
+# the Net::HTTP adapter.


### PR DESCRIPTION
## 追加機能
- 現在地の緯度経度を取得し、その地点から２km以内にある踏切のマーカーを地図上に表示する機能

## 使用gem・API
- Geolocation API
- gem 'geokit'
- gem 'geokit-rails'

## 参考URL
- geokit
https://github.com/geokit/geokit
- geokit-rails
https://github.com/geokit/geokit-rails
- Geolocation APIを使って現在位置を取得する
https://zenn.dev/sweflo/articles/8c34c081cb764c
- 【Rails】現在地の取得ってどうやるの？GeokitとGeocoderを使って現在地周辺施設の検索機能を実装してみた！
https://www.wantedly.com/companies/clueit/post_articles/44581
- GeocoderとGeokitを使用して、現在地周辺検索を行う機能を実装してみた
https://cluex-developers.hateblo.jp/entry/2016/08/31/170044