### PR TITLE
action_mailerの本番環境設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,8 +1,6 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
-  config.action_mailer.default_url_options = { host: 'https://railroad-crossing-app-eb89cd3a3946.herokuapp.com/', protocol: 'https' }
-
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
@@ -65,6 +63,18 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "railroad_crossing_app_production"
 
   config.action_mailer.perform_caching = false
+
+  config.action_mailer.default_url_options = { host: 'https://railroad-crossing-app-eb89cd3a3946.herokuapp.com/', protocol: 'https' }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    port: 587,
+    address:"smtp.gmail.com",
+    domain: 'gmail.com', #Gmailを使う場合
+    user_name: ENV['GMAIL_ADDRESS'], #Gmailアカウントのメールアドレス
+    password: ENV['GMAIL_PASSWORD'], #Gmailで設定したアプリパスワード
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
## 追加機能
- action_mailerの本番環境用の設定（config/environments/production.rb）

## 参考URL
- 本番環境でActionMailerを動かす 【Rails Heroku Gmail】
https://qiita.com/nichidai3_0514/items/4c7558a3076e5f8b83ca
- メールの設定
https://skillhub.jp/courses/137/lessons/977
- Googleのアプリパスワード（App passwords）が見つからない時の対処法
https://qiita.com/morima/items/58c51f7a35af2ed80050