### PR TITLE
トップページ以外のデザイン

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,20 @@
 //= require leaflet.markercluster
 //= require leaflet.markercluster.default
 @import "bootstrap";
+//=@import url('https://fonts.googleapis.com/css?family=Noto+Sans+JP');
+//=@import url('https://fonts.googleapis.com/css?family=M+PLUS+Rounded+1c');
+@import url('https://fonts.googleapis.com/css?family=M+PLUS+1p');
+
+body {
+  //=font-family: 'Noto Sans JP', sans-serif !important;
+  //=font-family: 'M PLUS Rounded 1c', sans-serif !important;
+  font-family: 'M PLUS 1p', sans-serif !important;
+}
+
+p {
+  margin-bottom: 0 !important;
+  font-weight: 100 !important;
+}
 
 .container {
   margin-top: 100px;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -14,7 +14,7 @@ class PostsController < ApplicationController
 
   def show
     @crossing = Crossing.includes(city: [:prefecture], linked_railways: [], posts: []).find(params[:crossing_id])
-    @post = Post.find(params[:id])
+    @post = Post.includes(:user).find(params[:id])
     @tags = @post.tag_counts_on(:tags)
     @favorites = @post.favorites
     @comment = Comment.new

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -10,13 +10,13 @@
     <td class="action">
       <ul class="list-inline justify-content-center" style="float: right;">
         <li class="list-inline-item">
-          <%= link_to "#", class: "edit-comment-link" do %>
-            <i class="bi bi-pen-fill"></i>
+          <%= link_to "#", class: "edit-comment-link btn btn-outline-info btn-sm rounded-pill py-0 px-2" do %>
+            <i class="bi bi-pencil-fill"></i>
           <% end %>
         </li>
         <li class="list-inline-item">
-          <%= link_to crossing_post_comment_path(comment.post.crossing_id, comment.post_id, comment), class: "delete-comment-link", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
-            <i class="bi bi-trash3-fill"></i>
+          <%= link_to crossing_post_comment_path(comment.post.crossing_id, comment.post_id, comment), class: "delete-comment-link btn btn-outline-danger btn-sm rounded-pill py-0 px-2", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
+            <i class="bi bi-trash-fill"></i>
           <% end %>
         </li>
       </ul>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -3,7 +3,7 @@
     <%= form_with model: [crossing, post, comment], url: crossing_post_comments_path(crossing.crossing_id, post.id), local: false do |f| %>
       <%= f.label :body %>
       <%= f.text_area :body, class: "form-control mb-3", row: "4", placeholder: Comment.human_attribute_name(:body) %>
-      <%= f.submit t('defaults.post'), class: "btn btn-warning" %>
+      <%= f.submit t('defaults.post'), class: "btn btn-outline-warning rounded-pill" %>
     <% end %>
   </div>
 </div>

--- a/app/views/crossings/show.html.erb
+++ b/app/views/crossings/show.html.erb
@@ -1,8 +1,11 @@
 <div class="container">
-  <%= render 'shared/crossing_info', crossing: @crossing %>
-  <div>
-    <%= link_to '投稿', new_crossing_post_path(@crossing.crossing_id), class: 'btn btn-warning' %>
+  <div class="pt-5">
+    <%= render 'shared/crossing_info', crossing: @crossing %>
+  </div>
+  <div class="d-flex justify-content-center mb-5">
+    <%= link_to 'このフミキリについて投稿する', new_crossing_post_path(@crossing.crossing_id), class: 'btn btn-warning rounded-pill shadow px-4' %>
   </div>
   <%# 投稿一覧 %>
+  <h3>このフミキリの投稿</h3>
   <%= render 'shared/post', posts: @posts %>
 </div>

--- a/app/views/favorites/_favorite.html.erb
+++ b/app/views/favorites/_favorite.html.erb
@@ -1,3 +1,3 @@
 <%= link_to favorites_path(post_id: post.id, crossing_id: crossing.crossing_id), id: "favorite-button-for-post-#{post.id}", data: { turbo_method: :post } do %>
-  <i class="bi bi-star"></i>
+  <i class="bi bi-hand-thumbs-up"></i>
 <% end%>

--- a/app/views/favorites/_unfavorite.html.erb
+++ b/app/views/favorites/_unfavorite.html.erb
@@ -1,3 +1,3 @@
 <%= link_to favorite_path(current_user.favorites.find_by(post_id: post.id), crossing_id: crossing.crossing_id), id: "unfavorite-button-for-post-#{post.id}", data: { turbo_method: :delete } do %>
-  <i class="bi bi-star-fill"></i>
+  <i class="bi bi-hand-thumbs-up-fill"></i>
 <% end %>

--- a/app/views/map_pages/top.html.erb
+++ b/app/views/map_pages/top.html.erb
@@ -15,8 +15,9 @@
       <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
     <div class="offcanvas-body d-flex flex-column">
+      <h5 class="text-secondary">フミキリを探す</h5>
       <div class="search-form">
-        <%= form_with model: @q, scope: :q, url: root_path, method: :get, class: 'flex-column mt-5' do |f| %>
+        <%= form_with model: @q, scope: :q, url: root_path, method: :get, class: 'flex-column mt-2' do |f| %>
           <%= f.select :city_prefecture_prefecture_id_eq, Prefecture.pluck(:prefecture_name, :prefecture_id), { include_blank: '都道府県' }, class: 'form-select shadow mt-3', id: 'select-prefecture' %>
           <%= f.select :city_city_id_eq, [], { include_blank: '市町村' }, class: 'form-select shadow mt-3', id: 'select-city' %>
           <div data-controller="autocomplete" data-autocomplete-url-value="/railway_search/search" role="combobox">
@@ -24,7 +25,7 @@
             <%= f.hidden_field :linked_railways_railway_name, data: { autocomplete_target: 'hidden' } %>
             <ul class="railroad-candidate list-group bg-white position-absolute list-unstyled fs-6 overflow-auto" data-autocomplete-target="results"></ul>
           </div>
-          <%= f.submit '検索', class: 'btn btn-warning form-control shadow mt-3 w-50' %>
+          <%= f.submit '検索', class: 'btn btn-warning form-control shadow mt-3 w-25' %>
           <% Prefecture.all.each do |prefecture| %>
             <template id="city-of-prefecture<%= prefecture.prefecture_id %>">
               <%= f.select :city_city_id_eq, prefecture.cities.pluck(:city_name, :city_id), { include_blank: '市町村' }, class: 'form-select shadow mt-3', id: 'select-city' %>
@@ -39,7 +40,7 @@
         <%= link_to 'お問い合わせ', new_contact_path, class: 'p-2 text-reset text-decoration-none' %>
       </div>
       <div class='copyright mt-4 text-secondary text-opacity-75'>
-        <p>Yasuaki Matsunaga portfolio</p>
+        <p>2024-2025 Yasuaki Matsunaga</p>
       </div>
     </div>
   </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -16,5 +16,7 @@
     <%= f.file_field :crossing_image, class: "form-control", accept: 'image/*' %>
     <%= f.hidden_field :crossing_image_cache %>
   </div>
-  <%= f.submit nil, class: "btn btn-warning" %>
+  <div class="d-flex justify-content-center">
+    <%= f.submit nil, class: "btn btn-warning rounded-pill shadow px-4" %>
+  </div>
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,20 +1,73 @@
 <div class="container">
   <h2>投稿一覧</h2>
-  <div class="search_form">
-    <%= form_with model: @q, scope: :q, url: posts_path, method: :get, class: 'd-flex justify-content-evenly p-2' do |f| %>
-      <%= f.select :crossing_city_prefecture_prefecture_id_eq, Prefecture.pluck(:prefecture_name, :prefecture_id), { include_blank: '都道府県' }, class: 'form-select shadow m-2' %>
-      <%= f.select :crossing_city_city_id_eq, City.pluck(:city_name, :city_id), { include_blank: '市町村' }, class: 'form-select shadow m-2' %>
-      <%= f.select :crossing_linked_railways_railway_id_eq, Railway.pluck(:railway_name, :railway_id), { include_blank: '路線' }, class: 'form-select shadow m-2' %>
-      <%= f.search_field :user_name_or_title_or_body_cont, class: 'form-control shadow m-2', placeholder: '検索ワード' %>
-      <%= f.submit '検索', class: 'btn btn-warning shadow m-2' %>
-    <% end %>
+  <div class="row">
+    <div class="search-area col-sm-12 col-md-4 col-lg-3">
+      <h5 class="mt-5">投稿を探す</h5>
+      <div class="search_form">
+        <%= form_with model: @q, scope: :q, url: posts_path, method: :get, class: 'flex-column mt-2' do |f| %>
+          <%= f.select :crossing_city_prefecture_prefecture_id_eq, Prefecture.pluck(:prefecture_name, :prefecture_id), { include_blank: '都道府県' }, class: 'form-select shadow mt-3', id: 'select-prefecture' %>
+          <%= f.select :crossing_city_city_id_eq, [], { include_blank: '市町村' }, class: 'form-select shadow mt-3', id: 'select-city' %>
+          <div data-controller="autocomplete" data-autocomplete-url-value="/railway_search/search" role="combobox">
+            <%= f.search_field :crossing_linked_railways_railway_name_cont, data: { autocomplete_target: 'input' }, class: 'form-control shadow mt-3', placeholder: '路線名を入力' %>
+            <%= f.hidden_field :crossing_linked_railways_railway_name, data: { autocomplete_target: 'hidden' } %>
+            <ul class="railroad-candidate list-group bg-white position-absolute list-unstyled fs-6 overflow-auto" data-autocomplete-target="results"></ul>
+          </div>
+          <%= f.search_field :user_name_or_title_or_body_cont, class: 'form-control shadow mt-3', placeholder: 'フリーワード' %>
+          <%= f.submit '検索', class: 'btn btn-warning shadow mt-3 w-25' %>
+          <% Prefecture.all.each do |prefecture| %>
+            <template id="city-of-prefecture<%= prefecture.prefecture_id %>">
+              <%= f.select :crossing_city_city_id_eq, prefecture.cities.pluck(:city_name, :city_id), { include_blank: '市町村' }, class: 'form-select shadow mt-3', id: 'select-city' %>
+            </template>
+          <% end %>
+        <% end %>
+      </div>
+      <div class="tag-list mt-5">
+        <h5 class="mt-5">タグ</h5>
+        <% @tags.each do |tag| %>
+          <span class="badge bg-dark-subtle mr-2 mb-2">
+            <%= link_to "#{tag.name}(#{tag.taggings_count})", posts_path(tag_name: tag.name), class: 'text-decoration-none text-secondary' %>
+          </span>
+        <% end %>
+      </div>
+    </div>
+    <div class="main-area col-sm-12 col-md-8 col-lg-9">
+      <%= render 'shared/post', posts: @posts %>
+    </div>
   </div>
-  <div class="tag-list">
-    <% @tags.each do |tag| %>
-      <span class="badge badge-info mr-2 mb-2">
-        <%= link_to "#{tag.name}(#{tag.taggings_count})", posts_path(tag_name: tag.name) %>
-      </span>
-    <% end %>
-  </div>
-  <%= render 'shared/post', posts: @posts %>
 </div>
+
+<script>
+// 取得したテキストをhtmlに変換する関数
+  function stringToHTML(str) {
+    var dom = document.createElement('div');
+    dom.innerHTML = str;
+    return dom.firstElementChild;
+  };
+
+//検索セレクトボックスを動的に変化させる
+  document.addEventListener('turbo:load', function () {
+    const selectPrefecture = document.getElementById("select-prefecture");
+    const defaultCitySelect = `<select class="form-select shadow mt-3" id="select-city" name="q[city_city_id_eq]">
+    <option value>市町村</option>
+    </select>`;
+
+    selectPrefecture.addEventListener('change', function() {
+      if (selectPrefecture.value !== '') {
+        const selectCity = document.getElementById("select-city");
+        selectCity.remove();
+
+        // 選択されたカテゴリーに応じたHTMLを挿入
+        let selectedTemplate = document.querySelector(`#city-of-prefecture${selectPrefecture.value}`);
+        selectPrefecture.after(stringToHTML(selectedTemplate.innerHTML));
+
+      } else {
+        const selectCity = document.getElementById("select-city");
+        // サブカテゴリー選択用のセレクトボックスを削除
+        selectCity.remove();
+        // ダミーのセレクトボックスを挿入
+        selectPrefecture.after(stringToHTML(defaultCitySelect));
+      };
+    });
+  });
+</script>
+

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,28 +1,21 @@
 <div class="container">
-  <%= render 'shared/crossing_info', crossing: @crossing %>
-  <div class="post-area d-flex justify-content-around">
-    <div class="crossing-image">
-      <%= image_tag @post.crossing_image.url %>
-    </div>
-    <div class="post-info">
-      <div class="post-title">
-        <h3><%= @post.title %></h3>
+  <div class="row pt-5">
+    <div class="post-body col-sm-12 col-md-8 col-lg-9">
+      <h3 class="post-title pb-3"><%= @post.title %></h3>
+      <div class="crossing-image d-flex justify-content-center pb-3">
+        <%= image_tag @post.crossing_image.url, class: 'img-fluid' %>
       </div>
-      <div class="tag-list">
-        <% @tags.each do |tag| %>
-          <span class="badge badge-info mr-2 mb-2">
-            <%= link_to "#{tag.name}(#{tag.taggings_count})", posts_path(tag_name: tag.name) %>
-          </span>
-        <% end %>
-      </div>
-      <div>
+      <h6>投稿者：<%= @post.user.name %></h6>
+      <div class="favorite-edit-delete-area d-flex align-items-center">
         <% if current_user && current_user.own?(@post) %>
-          <div class='ms-auto'>
-            <%= link_to edit_crossing_post_path(@post.crossing_id, @post.id), class: "btn btn-link p-0", id: "button-edit-#{@post.id}" do %>
-              <i class="bi bi-pen-fill"></i>
+          <div class='ms-auto d-flex'>
+            <%= link_to edit_crossing_post_path(@post.crossing_id, @post.id), class: "btn btn-outline-info btn-sm rounded-pill px-2 d-flex align-items-center gap-2", id: "button-edit-#{@post.id}" do %>
+              <i class="bi bi-pencil-fill"></i>
+              <p>編集</p>
             <% end %>
-            <%= link_to crossing_post_path(@post.crossing_id, @post.id), class: "btn btn-link p-0", id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' } do %>
-              <i class="bi bi-trash3-fill"></i>
+            <%= link_to crossing_post_path(@post.crossing_id, @post.id), class: "btn btn-outline-danger btn-sm rounded-pill px-2 mx-2 d-flex align-items-center gap-2", id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' } do %>
+              <i class="bi bi-trash-fill"></i>
+              <p>削除</p>
             <% end %>
           </div>
         <% else %>
@@ -30,23 +23,35 @@
             <%= render 'favorites/favorite_button', post: @post, crossing: @crossing %>
           </div>
         <% end %>
-        <div>
+        <div class="mx-4">
           <p>いいね <%= @favorites.count %></p>
         </div>
       </div>
-      <div class="post-body">
+      <div class="post-body col-12 col-md-8 col-lg-9 mb-4">
         <p><%= @post.body %></p>
       </div>
-      <%= render 'comments/form', crossing: @crossing, comment: @comment, post: @post %>
-      <div class="row">
-      <div class="col-lg-12">
-        <table class="table">
-          <tbody id="table-comment">
-            <%= render @comments %>
-          </tbody>
-        </table>
+      <div class="tag-list mb-4">
+        <% @tags.each do |tag| %>
+          <span class="badge bg-dark-subtle mr-2 mb-2">
+            <%= link_to "#{tag.name}(#{tag.taggings_count})", posts_path(tag_name: tag.name), class: 'text-decoration-none text-secondary' %>
+          </span>
+        <% end %>
+      </div>
+      <div class="comment-area px-3">
+        <%= render 'comments/form', crossing: @crossing, comment: @comment, post: @post %>
+        <div class="row">
+          <div class="col-lg-12">
+            <table class="table">
+              <tbody id="table-comment">
+                <%= render @comments %>
+              </tbody>
+            </table>
+          </div>
+        </div>
       </div>
     </div>
+    <div class="crossing-info-area col-12 col-md-4 col-lg-3">
+      <h5 class="mb-3">位置情報</h5>
+      <%= render 'shared/crossing_info', crossing: @crossing %>
     </div>
   </div>
-</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,6 +1,19 @@
 <div class="container">
-  <p>ユーザーネーム：<%= @user.name %></p>
-  <p>メールアドレス：<%= @user.email %></p>
-  <%= link_to 'プロフィール編集', edit_profile_path %>
-  <%= link_to 'パスワード変更', new_password_reset_path %>
+  <h2>プロフィール</h2>
+  <div class="row">
+    <nav class="navbar col-sm-12 col-md-4 col-lg-3">
+      <div class="collapse navbar-collapse d-flex flex-column text-secondary" id="navbarNavAltMarkup">
+        <div class="navbar-nav">
+          <%= link_to 'プロフィール', profile_path, class: 'p-2 text-reset text-decoration-none' %>
+          <%= link_to 'My投稿', '#', class: 'p-2 text-reset text-decoration-none' %>
+        </div>
+      </div>
+    </nav>
+    <div class="profile col-sm-12 col-md-8 col-lg-9 mt-5">
+      <p class="mb-3">ユーザーネーム：<%= @user.name %></p>
+      <p class="mb-3">メールアドレス：<%= @user.email %></p>
+      <%= link_to 'プロフィール編集', edit_profile_path, class: 'btn btn-secondary rounded-pill shadow mb-3' %>
+      <%= link_to 'パスワード変更', new_password_reset_path, class: 'btn btn-secondary rounded-pill shadow mb-3' %>
+    </div>
+  </div>
 </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -12,13 +12,13 @@
           <li class='nav-item'>
             <%= link_to posts_path, class: 'btn btn-warning rounded-pill shadow d-flex align-items-center gap-2', role: 'button' do %>
               <i class="bi bi-file-post"></i>
-              <p class="mb-0">投稿一覧</p>
+              <p>投稿一覧</p>
             <% end %>
           </li>
           <li class='nav-item'>
             <%= link_to login_path, class: "btn btn-warning rounded-pill shadow d-flex align-items-center gap-2" do %>
               <i class="bi bi-box-arrow-in-right"></i>
-              <p class="mb-0">ログイン</p>
+              <p>ログイン</p>
             <% end %>
           </li>
         </ul>

--- a/app/views/shared/_crossing_info.html.erb
+++ b/app/views/shared/_crossing_info.html.erb
@@ -1,14 +1,14 @@
-<div class="d-flex justify-content-between mb-5">
-  <div class="crossing-info">
-    <h2><%= crossing.crossing_name %></h2>
-    <h4>
+<div class="mb-5">
+  <div class="crossing-info text-center">
+    <h4><%= crossing.crossing_name %></h4>
+    <p class="mb-2">
       <%= link_to "#{crossing.latitude} / #{crossing.longitude}", "https://www.google.com/maps?q=#{crossing.latitude},#{crossing.longitude}", target: "_blank", rel: "noopener noreferrer" %>
-    </h4>
-    <h4><%= crossing.city.prefecture.prefecture_name %></h4>
-    <h4><%= crossing.city.city_name %></h4>
-    <h4><%= crossing.linked_railways.first.railway_name %></h4>
+    </p>
+    <p class="mb-2"><%= crossing.city.prefecture.prefecture_name %></p>
+    <p class="mb-2"><%= crossing.city.city_name %></p>
+    <p class="mb-2"><%= crossing.linked_railways.first.railway_name %></p>
   </div>
-  <div class="z-0" id="map" style="width: 65%; height: 250px;"></div>
+  <div class="z-0" id="map" style="width: 100%; height: 350px;"></div>
 </div>
 
 
@@ -16,9 +16,8 @@
   // 地図の初期設定
   var map = L.map('map').setView([<%= crossing.latitude %>, <%= crossing.longitude %>], 13);  // 東京の緯度経度を指定
 
-  // OSMタイルレイヤーを追加
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+  L.tileLayer('https://tile.thunderforest.com/transport/{z}/{x}/{y}.png?apikey=abd7cf1c7d9d4b06b660b84796899098' , {
+    attribution: '&copy; <a href="https://www.thunderforest.com/">Thunderforest</a> contributors'
   }).addTo(map);
 
   var marker = L.marker([<%= crossing.latitude %>, <%= crossing.longitude %>]).addTo(map);

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -12,19 +12,19 @@
           <li class='nav-item'>
             <%= link_to posts_path, class: 'btn btn-warning rounded-pill shadow d-flex align-items-center gap-2', role: 'button' do %>
               <i class="bi bi-file-post"></i>
-              <p class="mb-0">投稿一覧</p>
+              <p>投稿一覧</p>
             <% end %>
           </li>
           <li class='nav-item'>
             <%= link_to logout_path, class: 'btn btn-warning rounded-pill shadow d-flex align-items-center gap-2', data: { turbo_method: :delete } do %>
               <i class="bi bi-box-arrow-left"></i>
-              <p class="mb-0">ログアウト</p>
+              <p>ログアウト</p>
             <% end %>
           </li>
           <li class='nav-item'>
             <%= link_to profile_path, class: 'btn btn-warning rounded-pill shadow d-flex align-items-center gap-2' do %>
               <%= image_tag 'sample.jpg', class: 'rounded-circle', width: '25', height: '25' %>
-              <p class="mb-0"><%= current_user.name %></p>
+              <p><%= current_user.name %></p>
             <% end %>
           </li>
         </ul>

--- a/app/views/shared/_post.html.erb
+++ b/app/views/shared/_post.html.erb
@@ -1,27 +1,27 @@
 <div class="post-index my-4">
-  <div class="d-flex flex-wrap">
+  <div class="row">
     <% posts.each do |post| %>
-      <div class="mb-3 px-3" id="post-id-<%= post.id %>">
-        <div class="card" style="width: 18rem;">
+      <div class="col-12 col-md-6 col-lg-4 mb-3" id="post-id-<%= post.id %>">
+        <div class="card" style="width: 100%;">
           <%= image_tag post.crossing_image.url, class: "card-img-top" %>
           <div class="card-body">
-            <%= link_to post.title, crossing_post_path(post.crossing_id, post.id), class: 'card-title' %>
+            <%= link_to post.title, crossing_post_path(post.crossing_id, post.id), class: 'card-title text-decoration-none fw-semibold' %>
             <div class="d-flex">
               <p><%= post.user.name %></p>
               <% if current_user && current_user.own?(post) %>
                 <div class='ms-auto'>
-                  <%= link_to edit_crossing_post_path(post.crossing_id, post.id), class: "btn btn-link p-0", id: "button-edit-#{post.id}" do %>
-                    <i class="bi bi-pen-fill"></i>
+                  <%= link_to edit_crossing_post_path(post.crossing_id, post.id), class: "btn btn-outline-info btn-sm rounded-pill py-0 px-2", id: "button-edit-#{post.id}" do %>
+                    <i class="bi bi-pencil-fill"></i>
                   <% end %>
-                  <%= link_to crossing_post_path(post.crossing_id, post.id), class: "btn btn-link p-0", id: "button-delete-#{post.id}", data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' } do %>
-                    <i class="bi bi-trash3-fill"></i>
+                  <%= link_to crossing_post_path(post.crossing_id, post.id), class: "btn btn-outline-danger btn-sm rounded-pill py-0 px-2", id: "button-delete-#{post.id}", data: { turbo_method: :delete, turbo_confirm: '投稿を削除しますか？' } do %>
+                    <i class="bi bi-trash-fill"></i>
                   <% end %>
                 </div>
               <% end %>
             </div>
             <% post.tag_list.each do |tag| %>
-              <span class="badge badge-info mr-2 mb-2">
-                <%= link_to "#{tag}", posts_path(tag_name: tag) %>
+              <span class="badge bg-dark-subtle mr-2 mb-2">
+                <%= link_to "#{tag}", posts_path(tag_name: tag), class: 'text-decoration-none text-secondary' %>
               </span>
             <% end %>
           </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -7,15 +7,23 @@
           <%= f.label :email %>
           <%= f.email_field :email, class: "form-control" %>
         </div>
-        <div class="mb-3">
+        <div class="mb-4">
           <%= f.label :password %>
           <%= f.password_field :password, class: "form-control" %>
         </div>
-        <%= f.submit "ログイン", class: "btn btn-warning" %>
+        <div class="d-flex justify-content-center">
+          <%= f.submit "ログイン", class: "btn btn-warning rounded-pill shadow px-4" %>
+        </div>
       <% end %>
-      <div class='text-center'>
-        <%= link_to '登録ページへ', new_user_path %>
-        <%= link_to t('.password_forget'), new_password_reset_path %>
+      <div class="d-flex justify-content-center mt-4">
+        <%= link_to auth_at_provider_path(provider: :google), class: 'btn btn-primary rounded-pill shadow d-flex align-items-center px-4 gap-2' do %>
+          <i class="bi bi-google"></i>
+          <p>Login with Google</p>
+        <% end %>
+      </div>
+      <div class='text-center mt-4'>
+        <%= link_to 'アカウント登録', new_user_path, class: 'btn btn-secondary rounded-pill shadow mb-3 px-4' %>
+        <%= link_to t('.password_forget'), new_password_reset_path, class: 'btn btn-secondary rounded-pill shadow mb-3 px-4' %>
       </div>
     </div>
   </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -15,16 +15,20 @@
           <%= f.label :password, class: "form-label" %>
           <%= f.password_field :password, class: "form-control" %>
         </div>
-        <div class="mb-3">
+        <div class="mb-4">
           <%= f.label :password_confirmation, class: "form-label" %>
           <%= f.password_field :password_confirmation, class: "form-control" %>
         </div>
-        <%= f.submit "登録", class: "btn btn-warning" %>
+        <div class="d-flex justify-content-center">
+          <%= f.submit "登録", class: "btn btn-warning rounded-pill shadow px-4" %>
+        </div>
       <% end %>
-      <div class='text-center'>
-        <%= link_to 'ログインページへ', login_path %>
+      <div class="d-flex justify-content-center mt-4">
+        <%= link_to auth_at_provider_path(provider: :google), class: 'btn btn-primary rounded-pill shadow d-flex align-items-center px-4 gap-2' do %>
+          <i class="bi bi-google"></i>
+          <p>Login with Google</p>
+        <% end %>
       </div>
-      <%= link_to 'Login with Google', auth_at_provider_path(provider: :google) %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 追加・変更項目
- ログインページ、アカウント登録ページ、投稿一覧、新規投稿、投稿編集、踏切詳細ページ、投稿詳細ページのレイアウト
- サイト全体のフォントの変更（今後も変更あり）

## 参考URL
- 全部無料！CSSで指定できるおすすめフォントランキングBEST10
https://www.sejuku.net/blog/71621
- bootstrapでサイドバーの設定
https://qiita.com/zamazama/items/e29728011556af59d984