### PR TITLE
一部のhtml.erbファイルからjsを分離

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,7 +25,7 @@ p {
   bottom: 20px;
   right: 0;
   left: 0;
-  width: 300px;
+  width: 350px;
   height: 30px;
   margin: 0 auto;
   border: 0;

--- a/app/javascript/active_select_box.js
+++ b/app/javascript/active_select_box.js
@@ -1,0 +1,32 @@
+// 取得したテキストをhtmlに変換する関数
+function stringToHTML(str) {
+  var dom = document.createElement('div');
+  dom.innerHTML = str;
+  return dom.firstElementChild;
+};
+
+//検索セレクトボックスを動的に変化させる
+document.addEventListener('turbo:load', function () {
+  const selectPrefecture = document.getElementById("select-prefecture");
+  const defaultCitySelect = `<select class="form-select shadow mt-3" id="select-city" name="q[city_city_id_eq]">
+  <option value>市町村</option>
+  </select>`;
+
+  selectPrefecture.addEventListener('change', function() {
+    if (selectPrefecture.value !== '') {
+      const selectCity = document.getElementById("select-city");
+      selectCity.remove();
+
+      // 選択されたカテゴリーに応じたHTMLを挿入
+      let selectedTemplate = document.querySelector(`#city-of-prefecture${selectPrefecture.value}`);
+      selectPrefecture.after(stringToHTML(selectedTemplate.innerHTML));
+
+    } else {
+      const selectCity = document.getElementById("select-city");
+      // サブカテゴリー選択用のセレクトボックスを削除
+      selectCity.remove();
+      // ダミーのセレクトボックスを挿入
+      selectPrefecture.after(stringToHTML(defaultCitySelect));
+    };
+  });
+});

--- a/app/javascript/current_location.js
+++ b/app/javascript/current_location.js
@@ -1,0 +1,14 @@
+//現在地の取得と反映
+document.getElementById("get-location-btn").onclick = function(){
+  navigator.geolocation.getCurrentPosition(successCallback, errorCallback);
+};
+
+function successCallback(position){
+  var latitude = position.coords.latitude;
+  var longitude = position.coords.longitude;
+  window.location.href = `/?latitude=${latitude}&longitude=${longitude}`;
+};
+
+function errorCallback(error){
+  alert("位置情報が取得できませんでした");
+};

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,7 @@
     <%= render 'shared/flash_message' %>
     <main class="mb-auto">
       <%= yield %>
+      <%= yield(:js) %>
     </main>
     <% if request.path != '/' %>
       <%= render 'shared/footer' %>

--- a/app/views/map_pages/top.html.erb
+++ b/app/views/map_pages/top.html.erb
@@ -57,6 +57,11 @@
 
 </div>
 
+<% content_for :js do %>
+  <%= javascript_import_module_tag "active_select_box" %>
+  <%= javascript_include_tag "current_location", "data-turbo-track": "reload" %>
+<% end %>
+
 <script>
 //Mapの表示
   var map = L.map('map', {preferCanvas:true}).setView([35.6895, 139.6917], 13);  //東京
@@ -70,52 +75,4 @@
   <% @crossings.each do |crossing| %>
     var marker = L.marker([<%= crossing.latitude %>, <%= crossing.longitude %>]).addTo(map).bindPopup('<%= link_to "詳細", crossing_path(crossing.crossing_id) %>').openPopup();
   <% end %>
-
-//現在地の取得と反映
-  document.getElementById("get-location-btn").onclick = function(){
-    navigator.geolocation.getCurrentPosition(successCallback, errorCallback);
-  };
-
-  function successCallback(position){
-    var latitude = position.coords.latitude;
-    var longitude = position.coords.longitude;
-    window.location.href = `/?latitude=${latitude}&longitude=${longitude}`;
-  };
-
-  function errorCallback(error){
-      alert("位置情報が取得できませんでした");
-  };
-
-// 取得したテキストをhtmlに変換する関数
-  function stringToHTML(str) {
-    var dom = document.createElement('div');
-    dom.innerHTML = str;
-    return dom.firstElementChild;
-  };
-
-//検索セレクトボックスを動的に変化させる
-  document.addEventListener('turbo:load', function () {
-    const selectPrefecture = document.getElementById("select-prefecture");
-    const defaultCitySelect = `<select class="form-select shadow mt-3" id="select-city" name="q[city_city_id_eq]">
-    <option value>市町村</option>
-    </select>`;
-
-    selectPrefecture.addEventListener('change', function() {
-      if (selectPrefecture.value !== '') {
-        const selectCity = document.getElementById("select-city");
-        selectCity.remove();
-
-        // 選択されたカテゴリーに応じたHTMLを挿入
-        let selectedTemplate = document.querySelector(`#city-of-prefecture${selectPrefecture.value}`);
-        selectPrefecture.after(stringToHTML(selectedTemplate.innerHTML));
-
-      } else {
-        const selectCity = document.getElementById("select-city");
-        // サブカテゴリー選択用のセレクトボックスを削除
-        selectCity.remove();
-        // ダミーのセレクトボックスを挿入
-        selectPrefecture.after(stringToHTML(defaultCitySelect));
-      };
-    });
-  });
 </script>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,21 +1,23 @@
 <div class="container">
   <div class="row">
-    <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-      <h1><%= t('.title') %></h1>
+    <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <h1 class="mb-3"><%= t('.title') %></h1>
       <%= form_with model: @user, url: password_reset_path(@token), local: true do |f| %>
-        <div class="form-group">
+        <div class="form-group mb-3">
           <%= f.label :email %>
           <%= @user.email %>
         </div>
-        <div class="form-group">
+        <div class="form-group mb-3">
           <%= f.label :password %>
           <%= f.password_field :password, class: "form-control" %>
         </div>
-        <div class="form-group">
+        <div class="form-group mb-4">
           <%= f.label :password_confirmation %>
           <%= f.password_field :password_confirmation, class: "form-control" %>
         </div>
-        <%= f.submit "更新する", class: "btn btn-warning" %>
+        <div class="d-flex justify-content-center">
+          <%= f.submit "更新", class: "btn btn-warning rounded-pill shadow px-4" %>
+        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h2 class="mb-4">投稿一覧</h2>
+  <h2>投稿一覧</h2>
   <div class="row">
     <div class="search-area col-sm-12 col-md-4 col-lg-3">
       <h5 class="mt-5">投稿を探す</h5>
@@ -36,38 +36,6 @@
   </div>
 </div>
 
-<script>
-// 取得したテキストをhtmlに変換する関数
-  function stringToHTML(str) {
-    var dom = document.createElement('div');
-    dom.innerHTML = str;
-    return dom.firstElementChild;
-  };
-
-//検索セレクトボックスを動的に変化させる
-  document.addEventListener('turbo:load', function () {
-    const selectPrefecture = document.getElementById("select-prefecture");
-    const defaultCitySelect = `<select class="form-select shadow mt-3" id="select-city" name="q[city_city_id_eq]">
-    <option value>市町村</option>
-    </select>`;
-
-    selectPrefecture.addEventListener('change', function() {
-      if (selectPrefecture.value !== '') {
-        const selectCity = document.getElementById("select-city");
-        selectCity.remove();
-
-        // 選択されたカテゴリーに応じたHTMLを挿入
-        let selectedTemplate = document.querySelector(`#city-of-prefecture${selectPrefecture.value}`);
-        selectPrefecture.after(stringToHTML(selectedTemplate.innerHTML));
-
-      } else {
-        const selectCity = document.getElementById("select-city");
-        // サブカテゴリー選択用のセレクトボックスを削除
-        selectCity.remove();
-        // ダミーのセレクトボックスを挿入
-        selectPrefecture.after(stringToHTML(defaultCitySelect));
-      };
-    });
-  });
-</script>
-
+<% content_for :js do %>
+  <%= javascript_import_module_tag "active_select_box" %>
+<% end %>

--- a/app/views/shared/_crossing_info.html.erb
+++ b/app/views/shared/_crossing_info.html.erb
@@ -11,14 +11,14 @@
   <div class="z-0" id="map" style="width: 100%; height: 350px;"></div>
 </div>
 
-
 <script>
-  // 地図の初期設定
-  var map = L.map('map').setView([<%= crossing.latitude %>, <%= crossing.longitude %>], 13);  // 東京の緯度経度を指定
+  var map = L.map('map').setView([<%= crossing.latitude %>, <%= crossing.longitude %>], 13);
 
   L.tileLayer('https://tile.thunderforest.com/transport/{z}/{x}/{y}.png?apikey=abd7cf1c7d9d4b06b660b84796899098' , {
     attribution: '&copy; <a href="https://www.thunderforest.com/">Thunderforest</a> contributors'
   }).addTo(map);
 
-  var marker = L.marker([<%= crossing.latitude %>, <%= crossing.longitude %>]).addTo(map);
+  var marker = L.marker([<%= crossing.latitude %>, <%= crossing.longitude %>]).addTo(map).bindPopup('<%= link_to "詳細", crossing_path(crossing.crossing_id) %>').openPopup();
+
+  map.zoomControl.setPosition("bottomright");
 </script>

--- a/app/views/shared/_post.html.erb
+++ b/app/views/shared/_post.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <% posts.each do |post| %>
       <div class="col-12 col-md-6 col-lg-4 mb-3" id="post-id-<%= post.id %>">
-        <div class="card" style="width: 100%;">
+        <div class="card shadow-sm" style="width: 100%;">
           <%= image_tag post.crossing_image.url, class: "card-img-top" %>
           <div class="card-body">
             <%= link_to post.title, crossing_post_path(post.crossing_id, post.id), class: 'card-title text-decoration-none fw-semibold' %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,3 +8,4 @@ pin_all_from "app/javascript/controllers", under: "controllers"
 pin "bootstrap", to: "bootstrap.min.js", preload: true
 pin "@popperjs/core", to: "popper.js", preload: true
 pin "stimulus-autocomplete" # @3.1.0
+pin "active_select_box"


### PR DESCRIPTION
## 変更・追加事項
- 都道府県・市町村検索の動的セレクトボックスのJavaScriptをactive_select_box.jsに分離
- 現在地検索のJavaScriptをcurrent_location.jsに分離
- active_select_box.jsは、map_pages/top.html.erbとposts/index.html.erbで使用。
- current_location.jsは、map_pages/top.html.erbで使用。
- マップ表示のJavaScriptの分離は、今後必要があれば行う。（使いまわさないから必要ない？）

## 参考URL
- Rails 7 でファイルごとに JavaScript を分けて使えるようにする
https://zenn.dev/yama525/articles/8537244b477059
- Railsで、任意のJavaScriptやCSSだけを読み込む
https://qiita.com/Oakbow/items/2e712e05bb4bbf68faf5
- JavaScriptをインクルード
https://railsdoc.com/page/javascript_include_tag