### PR TITLE
ユーザーモデルスペック

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,6 @@
 class Post < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
-  validates :body, presence: true, length: { maximum: 65_535 }
+  validates :body, length: { maximum: 65_535 }
   validates :crossing_image, presence: true
 
   belongs_to :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
-  validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
+  validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validates :name, presence: true, length: { maximum: 255 }

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -27,7 +27,5 @@ ja:
       models:
         post:
           attributes:
-            title:
-              blank: "を入力してください"
             crossing_image:
               blank: "をアップロードしてください"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  before do
+    @user = build(:user)
+  end
+
+  describe 'ユーザー新規登録' do
+    context '新規登録が成功する' do
+      it '内容に問題ない場合' do
+        expect(@user).to be_valid
+      end
+    end
+    context '新規登録が失敗する' do
+      it 'name（ユーザーネーム）が空のとき' do
+        @user.name = ''
+        @user.valid?
+        expect(@user.errors).to be_added(:name, :blank)
+      end
+      it 'name（ユーザーネーム）が256文字以上のとき' do
+        @user.name = 'a' * 256
+        @user.valid?
+        expect(@user.errors).to be_added(:name, :too_long, count: 255)
+      end
+      it 'email（メールアドレス）が空のとき' do
+        @user.email = ''
+        @user.valid?
+        expect(@user.errors).to be_added(:email, :blank)
+      end
+      it "重複したemailが存在する場合登録できない" do
+        @user.save
+        another_user = FactoryBot.build(:user)
+        another_user.email = @user.email
+        another_user.valid?
+        expect(another_user.errors.full_messages).to include("メールアドレスはすでに存在します")
+      end
+      it 'password（パスワード）が空のとき' do
+        @user.password = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("パスワードは6文字以上で入力してください")
+      end
+      it 'password（パスワード）が5文字以下のとき' do
+        @user.password = 'abcde'
+        @user.valid?
+        expect(@user.errors).to be_added(:password, :too_short, count: 6)
+      end
+      it 'password_confirmation（パスワード確認）が空のとき' do
+        @user.password_confirmation = ''
+        @user.valid?
+        expect(@user.errors).to be_added(:password_confirmation, :blank)
+      end
+      it "passwordが存在してもpassword_confirmationが空では登録できない" do
+        @user.password = 'abcdef'
+        @user.password_confirmation = ''
+        @user.valid?
+        expect(@user.errors).to be_added(:password_confirmation, :confirmation, attribute: "パスワード")
+      end
+      it "passwordとpassword_confirmationが一致していなければ登録できない" do
+        @user.password = 'abcdef'
+        @user.password_confirmation = '123456'
+        @user.valid?
+        expect(@user.errors).to be_added(:password_confirmation, :confirmation, attribute: "パスワード")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 追加事項
- Userのモデルスペック（models/user_spec.rb）

## 参考URL
- 【Rails6】 RSpecによるUserのモデル単体テストの実装
https://qiita.com/narimiya/items/8ec3cdc15b1134b04dce
- どのフィールドにどの検証エラーが追加されたのかを、「表示言語やエラーメッセージに依存しない形で」テストする方法
https://qiita.com/jnchito/items/6cf94a82e719c1dca5f1
- Rails 国際化（I18n）API
https://railsguides.jp/i18n.html#%E3%82%A8%E3%83%A9%E3%83%BC%E3%83%A1%E3%83%83%E3%82%BB%E3%83%BC%E3%82%B8%E3%81%AE%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%97
- 【Rails】RSpecマッチャー一覧
https://qiita.com/P-man_Brown/items/25e63a9a870353fe0aea