### PR TITLE
sorcery:remember_meサブモジュールの導入

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,7 +20,7 @@ body {
   background-color: $light;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1, h2, h3, h4, h5, h6, label {
   color: $info;
 }
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,7 +6,7 @@ class UserSessionsController < ApplicationController
   end
 
   def create
-    @user = login(params[:email], params[:password])
+    @user = login(params[:email], params[:password], params[:remember])
 
     if @user
       redirect_to root_path, success: t('user_sessions.create.success')
@@ -18,6 +18,8 @@ class UserSessionsController < ApplicationController
   end
 
   def destroy
+    remember_me!
+    forget_me!
     logout
     redirect_to root_path, status: :see_other, success: t('.success')
   end

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -12,11 +12,15 @@
           <%= f.label :password %>
           <%= f.password_field :password, class: "form-control border-0 shadow" %>
         </div>
+        <div class="d-flex justify-content-center mb-2">
+          <%= f.label :remember_me, "ログイン状態を保持する", class:'me-2' %>
+          <%= f.check_box :remember_me %>
+        </div>
         <div class="d-flex justify-content-center">
           <%= f.submit "ログイン", class: "btn btn-warning rounded-pill shadow px-4", value: "ログイン" %>
         </div>
       <% end %>
-      <div class="d-flex justify-content-center mt-4">
+      <div class="d-flex justify-content-center mt-5">
         <%= link_to auth_at_provider_path(:google), class: 'btn btn-primary rounded-pill shadow d-flex align-items-center px-4 gap-2', data: { turbo: false } do %>
           <i class="bi bi-google text-light"></i>
           <p class="text-light">Login with Google</p>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [:reset_password, :external]
+Rails.application.config.sorcery.submodules = [:reset_password, :external, :remember_me]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -330,7 +330,7 @@ Rails.application.config.sorcery.configure do |config|
     # How long in seconds the session length will be
     # Default: `60 * 60 * 24 * 7`
     #
-    # user.remember_me_for =
+    user.remember_me_for = 1209600 # Two weeks in seconds
 
     # When true, sorcery will persist a single remember me token for all
     # logins/logouts (to support remembering on multiple browsers simultaneously).

--- a/db/migrate/20250516091016_sorcery_remember_me.rb
+++ b/db/migrate/20250516091016_sorcery_remember_me.rb
@@ -1,0 +1,8 @@
+class SorceryRememberMe < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :remember_me_token, :string, default: nil
+    add_column :users, :remember_me_token_expires_at, :datetime, default: nil
+
+    add_index :users, :remember_me_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_05_01_081241) do
+ActiveRecord::Schema[7.0].define(version: 2025_05_16_091016) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -139,7 +139,10 @@ ActiveRecord::Schema[7.0].define(version: 2025_05_01_081241) do
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
     t.string "avatar"
+    t.string "remember_me_token"
+    t.datetime "remember_me_token_expires_at"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
## 追加事項
- sorceryのremember_meサブモジュールを導入し、ログイン状態を保持する機能を追加。
- 基本的には、remember_meの公式チュートリアルを参考に実装。

## 参考URL
- Remember Me
https://github.com/Sorcery/sorcery/wiki/Remember-Me
- Sorceryで認証機能を実装してみた
https://qiita.com/k12da/items/b3eb240a28d50f7832cb