### PR TITLE
Googleアナリティクスの設定

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,16 @@
     <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
     <%= javascript_importmap_tags %>
     <%= display_meta_tags(default_meta_tags) %>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-QN2G27XZPS"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-QN2G27XZPS');
+    </script>
   </head>
 
   <body class="d-flex flex-column vh-100">


### PR DESCRIPTION
## 追加事項
- Googleアナリティクスのアカウント作成
- application.html.erbにGoogleアナリティクス用のタグを追加

## 参考URL
- [GA4] アナリティクスで新しいウェブサイトまたはアプリのセットアップを行う
https://support.google.com/analytics/answer/9304153
- 【Rails7】Google Analytics 4（GA4）を導入する
https://zenn.dev/yoiyoicho/articles/1fe05797a1bbc4