### PR TITLE
BootstrapのSass利用のため、node_modulesをアセットパスに追加

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,8 +9,8 @@ Rails.application.config.assets.version = "1.0"
 # 特に問題なければ後で削除
 # Rails.application.config.assets.precompile += %w(bootstrap.min.js popper.js)
 
-# 特に問題なければ後で削除
-# Rails.application.config.assets.paths << Rails.root.join('node_modules')
+# for use sass of bootstrap
+Rails.application.config.assets.paths << Rails.root.join('node_modules')
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets


### PR DESCRIPTION
## 修正事項
herokuへのデプロイ時、以下のようなエラーが出たため、config/initializers/assets.rbを修正
Error: Can't find stylesheet to import.
11 │ @import "bootstrap/scss/bootstrap";

config/initializers/assets.rbにrails7.1アップデート前には存在していた以下の記述を復活させる。
Rails.application.config.assets.paths << Rails.root.join('node_modules')

Rails 7.1 以降では、importmap を使う構成が標準になっているが、 application.scss で Sass ベースの Bootstrap を @import "bootstrap/scss/bootstrap"; として利用する場合は、Sprockets のアセットパイプラインに node_modules を通す必要あり。
