### PR TITLE
net-imap 0.4.20 以上にアップグレード dependabot対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem 'geokit-rails'
 
 gem 'gon'
 
+# github dependabotにより追加
+gem "net-imap", ">= 0.4.20"
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 # gem "rails", "~> 7.0.8", ">= 7.0.8.4"
 gem "rails", "~> 7.1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
       railties (>= 6.0.0)
     dartsass-rails (0.4.1)
       railties (>= 6.0.0)
-    date (3.3.4)
+    date (3.4.1)
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -289,7 +289,7 @@ GEM
     mutex_m (0.3.0)
     net-http (0.6.0)
       uri
-    net-imap (0.4.16)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -532,6 +532,7 @@ DEPENDENCIES
   letter_opener_web (~> 3.0)
   meta-tags
   mini_magick
+  net-imap (>= 0.4.20)
   pg
   pry
   pry-byebug


### PR DESCRIPTION
## 修正事項
以下のdependabot alerts対応のためgem "net-imap"を0.4.20以上にアップデート
- net-imap rubygem vulnerable to possible DoS by memory exhaustion
- Possible DoS by memory exhaustion in net-imap