### PR TITLE
rexmlを3.3.9以上にアップデート dependabot対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'gon'
 
 # github dependabotにより追加
 gem "net-imap", ">= 0.4.20"
+gem "rexml", ">= 3.3.9"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 # gem "rails", "~> 7.0.8", ">= 7.0.8.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,7 +389,7 @@ GEM
       io-console (~> 0.5)
     request_store (1.7.0)
       rack (>= 1.4)
-    rexml (3.3.8)
+    rexml (3.4.1)
     rouge (4.4.0)
     rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
@@ -541,6 +541,7 @@ DEPENDENCIES
   rails-i18n (~> 7.0.0)
   ransack (>= 4.1)
   redcarpet
+  rexml (>= 3.3.9)
   rspec-rails
   rspec_junit_formatter
   rubocop


### PR DESCRIPTION
## 修正事項
以下のdependabot alertsの対応としてgem "rexml"を3.3.9以上にアップデート
REXML ReDoS vulnerability