### PR TITLE
rails-html-sanitizerを1.6.1以上にアップデート dependabot対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem 'gon'
 # github dependabotにより追加
 gem "net-imap", ">= 0.4.20"
 gem "rexml", ">= 3.3.9"
+gem "rails-html-sanitizer", ">= 1.6.1"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 # gem "rails", "~> 7.0.8", ">= 7.0.8.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,7 +262,7 @@ GEM
       railties (>= 6.1)
       rexml
     logger (1.7.0)
-    loofah (2.22.0)
+    loofah (2.24.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -361,9 +361,9 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.0)
+    rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
-      nokogiri (~> 1.14)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails-i18n (7.0.9)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
@@ -538,6 +538,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 5.0)
   rails (~> 7.1.3)
+  rails-html-sanitizer (>= 1.6.1)
   rails-i18n (~> 7.0.0)
   ransack (>= 4.1)
   redcarpet


### PR DESCRIPTION
## 修正事項
以下のdependabot alertdに対応するため、gem "rails-html-sanitizer"を1.6.1以上にアップデート
rails-html-sanitizer has XSS vulnerability with certain configurations

## 参考URL
今更ながら、bundle installとbundle updateの違いを確認
- bundle install と bundle updateの違いについて
https://qiita.com/lasershow/items/1a048d03ddaaba98171e
- bundle install と bundle update の違い
https://forest-valley17.hatenablog.com/entry/2018/09/08/120108