### PR TITLE
パンくずリストの設置

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ gem 'geokit-rails'
 
 gem 'gon'
 
+gem 'gretel'
+
 # github dependabotにより追加
 gem "net-imap", ">= 0.4.20"
 gem "rexml", ">= 3.3.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,9 @@ GEM
       i18n (>= 0.7)
       multi_json
       request_store (>= 1.0)
+    gretel (5.0.1)
+      actionview (>= 6.1)
+      railties (>= 6.1)
     hashie (5.0.0)
     high_voltage (4.0.0)
     i18n (1.14.7)
@@ -520,6 +523,7 @@ DEPENDENCIES
   geokit
   geokit-rails
   gon
+  gretel
   high_voltage
   image_processing (~> 1.2)
   importmap-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,16 +34,12 @@ footer {
   margin-top: 100px;
 }
 
-.container {
-  margin-top: 150px;
-}
-
 .flash-message {
   position: fixed;
   bottom: 20px;
   right: 0;
   left: 0;
-  width: 350px;
+  width: 400px;
   height: 30px;
   margin: 0 auto;
   border: 0;
@@ -66,6 +62,10 @@ footer {
 
 .railroad-candidate {
   max-height: 300px;
+}
+
+.fixed-breadcrumb {
+  margin-top: 120px;
 }
 
 @media (max-width: 576px) {

--- a/app/views/crossings/show.html.erb
+++ b/app/views/crossings/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, "#{@crossing.latitude}/#{@crossing.longitude}") %>
+<%= render 'shared/breadcrumbs' %>
 <div class="container">
   <div class="pt-5">
     <%= render 'shared/crossing_info', crossing: @crossing %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,6 +41,11 @@
       <% end %>
     <% end %>
     <%= render 'shared/flash_message' %>
+    <% unless current_page?(root_path) %>
+      <div class="fixed-breadcrumb w-100 bg-light">
+        <%= breadcrumbs separator: " &rsaquo; " %>
+      </div>
+    <% end %>
     <main class="mb-auto">
       <%= yield %>
       <%= yield(:js) %>

--- a/app/views/my_posts/index.html.erb
+++ b/app/views/my_posts/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:title, t('.title')) %>
-<div class="container">
+<%= render 'shared/breadcrumbs' %>
+<div class="container pt-5">
   <h2 class="mb-4">My投稿</h2>
   <div class="row">
     <%= render 'shared/account_page_side' %>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, t('.title')) %>
+<%= render 'shared/breadcrumbs' %>
 <div class="container">
   <div class="row">
     <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, t('.title')) %>
+<%= render 'shared/breadcrumbs' %>
 <div class="container">
   <div class="row">
     <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:title, t('.title')) %>
-<div class="container">
+<%= render 'shared/breadcrumbs' %>
+<div class="container pt-5">
   <div class="row">
     <div class="col-lg-8 offset-lg-2">
       <h2>投稿編集</h2>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:title, t('.title')) %>
-<div class="container">
+<%= render 'shared/breadcrumbs' %>
+<div class="container pt-5">
   <h2>投稿一覧</h2>
   <div class="row">
     <div class="search-area col-sm-12 col-md-4 col-lg-3 pb-5">

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, t('.title')) %>
+<%= render 'shared/breadcrumbs' %>
 <div class="container">
   <div class="row">
     <div class="col-lg-8 offset-lg-2 pb-3">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, @post.title) %>
+<%= render 'shared/breadcrumbs' %>
 <div class="container">
   <div class="row pt-5">
     <div class="post-body col-sm-12 col-md-8 col-lg-9">

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:title, t('.title')) %>
-<div class="container">
+<%= render 'shared/breadcrumbs' %>
+<div class="container pt-5">
   <div class="row">
     <div class="col-md-10 col-lg-8 mx-auto">
       <h2 class="mb-4">プロフィール編集</h2>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:title, t('.title')) %>
-<div class="container">
+<%= render 'shared/breadcrumbs' %>
+<div class="container pt-5">
   <h2 class="mb-4">プロフィール</h2>
   <div class="row">
     <%= render 'shared/account_page_side' %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -18,7 +18,7 @@
           <li class="nav-item">
             <%= link_to new_user_path, class: 'btn btn-warning rounded-pill shadow d-flex align-items-center gap-2', role: 'button' do %>
               <i class="bi bi-person-circle"></i>
-              <span class="mb-0">アカウント登録</span>
+              <span class="mb-0">ユーザー登録</span>
             <% end %>
           </li>
           <li class="nav-item">

--- a/app/views/shared/_before_login_root_header.html.erb
+++ b/app/views/shared/_before_login_root_header.html.erb
@@ -13,7 +13,7 @@
           <li class='nav-item'>
             <%= link_to new_user_path, class: 'btn btn-warning rounded-pill shadow d-flex align-items-center gap-2', role: 'button' do %>
               <i class="bi bi-person-circle"></i>
-              <span class="mb-0">アカウント登録</span>
+              <span class="mb-0">ユーザー登録</span>
             <% end %>
           </li>
           <li class='nav-item'>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,0 +1,41 @@
+<% case params.values_at(:controller, :action) %>
+<% when ['users', 'new'] %>
+  <% breadcrumb :user_new %>
+
+<% when ['user_sessions', 'new'] %>
+  <% breadcrumb :login %>
+
+<% when ['password_resets', 'new'] %>
+  <% breadcrumb :password_reset %>
+
+<% when ['password_resets', 'edit'] %>
+  <% breadcrumb :password_edit, @user %>
+
+<% when ['crossings', 'show'] %>
+  <% breadcrumb :crossing, @crossing %>
+
+<% when ['posts', 'index'] %>
+  <% breadcrumb :posts %>
+
+<% when ['posts', 'show'] %>
+  <% breadcrumb :post, @post %>
+
+<% when ['posts', 'new'] %>
+  <% breadcrumb :post_new, @crossing %>
+
+<% when ['posts', 'edit'] %>
+  <% if params[:controller] == 'posts' && params[:action] == 'edit' && request.referer&.include?('/posts') %>
+    <% breadcrumb :post_edit, @post, from: :posts %>
+  <% else %>
+    <% breadcrumb :post_edit, @post %>
+  <% end %>
+
+<% when ['profiles', 'show'] %>
+  <% breadcrumb :profile %>
+
+<% when ['profiles', 'edit'] %>
+  <% breadcrumb :profile_edit %>
+
+<% when ['my_posts', 'index'] %>
+  <% breadcrumb :my_posts %>
+<% end %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:title, t('.title')) %>
-<div class="container">
+<%= render 'shared/breadcrumbs' %>
+<div class="container pt-5">
   <div class="row">
     <div class=" col-md-10 col-lg-8 mx-auto">
       <h2 class="mb-4">ログイン</h2>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:title, t('.title')) %>
-<div class="container">
+<%= render 'shared/breadcrumbs' %>
+<div class="container pt-5">
   <div class="row">
     <div class="col-md-10 col-lg-8 mx-auto my-3">
       <h2  class="mb-4">ユーザー登録</h2>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,88 @@
+crumb :root do
+  link "トップ", root_path
+end
+
+crumb :user_new do
+  link "ユーザー登録", new_user_path
+  parent :root
+end
+
+crumb :login do
+  link "ログイン", login_path
+  parent :root
+end
+
+crumb :password_reset do
+  link "パスワードリセット申請", new_password_reset_path
+  parent :login
+end
+
+crumb :password_edit do |user|
+  link "パスワードリセット", edit_password_reset_path(user)
+  parent :password_reset
+end
+
+crumb :crossing do |crossing|
+  link "#{crossing.latitude}/#{crossing.longitude} (#{crossing.city.prefecture.prefecture_name} #{crossing.city.city_name})", crossing_path(crossing.crossing_id)
+  parent :root
+end
+
+crumb :post do |post|
+  link "#{post.title} (#{post.crossing.city.prefecture.prefecture_name} #{post.crossing.city.city_name})", crossing_post_path(post.crossing, post)
+  parent :crossing, post.crossing
+end
+
+crumb :posts do
+  link "投稿一覧", posts_path
+  parent :root
+end
+
+crumb :post_new do |crossing|
+  link "新規投稿", new_crossing_post_path(crossing)
+  parent :crossing, crossing
+end
+
+crumb :post_edit do |post|
+  link "投稿編集", edit_crossing_post_path(post.crossing, post)
+  parent :post, post
+end
+
+crumb :profile do
+  link "プロフィール", profile_path
+  parent :root
+end
+
+crumb :profile_edit do
+  link "プロフィール編集", edit_profile_path
+  parent :profile
+end
+
+crumb :my_posts do
+  link "My投稿", my_posts_path
+  parent :profile
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
## 追加事項
- gem"gretel"を利用して、パンくずリストを設置
- パンくずリストのviewは、<%= render 'shared/breadcrumbs' %>でパーシャル化
- パーシャルは、shared/_breadcrumbs.html.erbに記述。
- shared/_breadcrumbs.html.erb内でコントローラーとアクションを指定して表示するパンくずリストを分岐

## 参考URL
- gretel
https://github.com/kzkn/gretel?tab=readme-ov-file
- 【Rails】 パンくずリストとは
https://qiita.com/mmaumtjgj/items/95a3b25f9b08da004997
- 一番わかりやすいパンくずの実装（gem 'gretel')
https://qiita.com/params_bird/items/2c77ac1fe6ea8c4fd065