### PR TITLE
gem nokogiriのアップデート

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,8 @@ gem 'gretel'
 
 gem 'sitemap_generator'
 
+gem 'nokogiri', '>= 1.18.9'
+
 # github dependabotにより追加
 gem "net-imap", ">= 0.4.20"
 gem "rexml", ">= 3.3.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,9 +302,9 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
-    nokogiri (1.18.8-aarch64-linux-gnu)
+    nokogiri (1.18.9-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-linux-gnu)
+    nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth (1.1.0)
       oauth-tty (~> 1.0, >= 1.0.1)
@@ -539,6 +539,7 @@ DEPENDENCIES
   meta-tags
   mini_magick
   net-imap (>= 0.4.20)
+  nokogiri (>= 1.18.9)
   pg
   pry
   pry-byebug


### PR DESCRIPTION
## 修正事項
- gem "nokogiri"を1.18.9以上にアップデート（Dependabot alerts 対応）
