### PR TITLE
gem thorを1.4.0以上にアップデート（dependabot対応）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ gem 'nokogiri', '>= 1.18.9'
 gem "net-imap", ">= 0.4.20"
 gem "rexml", ">= 3.3.9"
 gem "rails-html-sanitizer", ">= 1.6.1"
+gem "thor", ">= 1.4.0"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 # gem "rails", "~> 7.0.8", ">= 7.0.8.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,7 +470,7 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.1)
-    thor (1.3.2)
+    thor (1.4.0)
     timeout (0.4.1)
     turbo-rails (2.0.16)
       actionpack (>= 7.1.0)
@@ -562,6 +562,7 @@ DEPENDENCIES
   sorcery (~> 0.17.0)
   sprockets-rails
   stimulus-rails
+  thor (>= 1.4.0)
   turbo-rails
   tzinfo-data
   web-console


### PR DESCRIPTION
以下のdependabot alertに対応
Thor can construct an unsafe shell command from library input. #26
gem "thor"を">= 1.4.0"にしてしてアップデート